### PR TITLE
fix: Logger formatter issue preventing GKE jobs from running

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "playwright>=1.40.0",
     "aws-lambda-powertools[all]>=2.25.0",
+    "python-json-logger>=2.0.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -82,8 +82,15 @@ class MLSScraperLogger:
                 underlying_logger = logging.getLogger(self._logger.name)
                 underlying_logger.handlers.clear()
 
+                # Create JSON formatter compatible with Powertools Logger
+                from pythonjsonlogger import jsonlogger
+
                 file_handler = logging.FileHandler(log_file_path)
-                file_handler.setFormatter(self._logger._get_log_formatter())
+                json_formatter = jsonlogger.JsonFormatter(
+                    '%(timestamp)s %(level)s %(service)s %(name)s %(message)s',
+                    timestamp=True
+                )
+                file_handler.setFormatter(json_formatter)
                 underlying_logger.addHandler(file_handler)
 
                 # Also log to stderr for kubectl logs visibility (without JSON formatting)


### PR DESCRIPTION
## Problem

GKE pods were crashing with:
```
AttributeError: 'Logger' object has no attribute '_get_log_formatter'
```

The code was trying to access a private method `_get_log_formatter()` on AWS Lambda Powertools Logger, which doesn't exist.

## Solution

- Replace private API call with `python-json-logger` for proper JSON formatting
- Add `python-json-logger>=2.0.0` dependency
- Maintains structured JSON logging for Loki/Promtail collection

## Testing

After merge, can run match-scraper job in GKE to verify metrics flow to Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>