### PR TITLE
feat: Add --from and --to date support to trigger script

### DIFF
--- a/scripts/README-trigger.md
+++ b/scripts/README-trigger.md
@@ -8,8 +8,11 @@ CLI tool for manually triggering match-scraper jobs on GKE with custom parameter
 # Basic usage with defaults (today to +13 days, U14 Northeast)
 ./scripts/trigger-gke-job.sh
 
-# Custom date range
+# Custom date range (offset-based)
 ./scripts/trigger-gke-job.sh --start=0 --end=13
+
+# Absolute date range (no math required!)
+./scripts/trigger-gke-job.sh --from=2025-10-01 --to=2025-11-01
 
 # Last 7 days
 ./scripts/trigger-gke-job.sh --start=-7 --end=0
@@ -24,11 +27,15 @@ CLI tool for manually triggering match-scraper jobs on GKE with custom parameter
 |--------|-------------|---------|
 | `--start N` | Start date offset (0=today, negative=past) | 0 |
 | `--end N` | End date offset | 13 |
+| `--from DATE` | Absolute start date (YYYY-MM-DD) | - |
+| `--to DATE` | Absolute end date (YYYY-MM-DD) | - |
 | `--age-group GROUP` | Age group to scrape | U14 |
 | `--division DIV` | Division to scrape | Northeast |
 | `--namespace NS` | Kubernetes namespace | match-scraper |
 | `--no-follow` | Don't follow logs (just create job) | false |
 | `-h, --help` | Show help message | - |
+
+**Note:** Use either `--start`/`--end` (offset-based) OR `--from`/`--to` (absolute dates), not both.
 
 ## Features
 
@@ -58,6 +65,11 @@ CLI tool for manually triggering match-scraper jobs on GKE with custom parameter
 ### U16 Southeast Division
 ```bash
 ./scripts/trigger-gke-job.sh --age-group=U16 --division=Southeast --start=0 --end=14
+```
+
+### Absolute Date Range (Oct 1 to Nov 1)
+```bash
+./scripts/trigger-gke-job.sh --from=2025-10-01 --to=2025-11-01
 ```
 
 ### Create Job Without Watching Logs


### PR DESCRIPTION
## Changes

Add support for absolute date ranges using `--from` and `--to` flags in the GKE job trigger script.

## Why?

Using offset-based dates (`--start` and `--end`) requires mental math to figure out how many days ago/forward a specific date is. Absolute dates are much more intuitive:

**Before:**
```bash
# Today is Oct 7, want Oct 1 to Nov 1
# Oct 1 = 6 days ago, Nov 1 = 25 days from now
./scripts/trigger-gke-job.sh --start=-6 --end=25
```

**After:**
```bash
# Just specify the dates directly - no math!
./scripts/trigger-gke-job.sh --from=2025-10-01 --to=2025-11-01
```

## Implementation

- Added `--from` and `--to` argument parsing (supports both `--from=DATE` and `--from DATE`)
- Script automatically builds the correct CLI command based on which flags are used
- Updated help text and README with examples
- Backwards compatible - existing `--start`/`--end` usage still works

## Examples

```bash
# Absolute dates (no math required!)
./scripts/trigger-gke-job.sh --from=2025-10-01 --to=2025-11-01

# With specific age group
./scripts/trigger-gke-job.sh --from=2025-10-01 --to=2025-11-01 --age-group=U13

# Offset-based (still works)
./scripts/trigger-gke-job.sh --start=-7 --end=0

# Different age group with absolute dates
./scripts/trigger-gke-job.sh --from=2025-10-15 --to=2025-11-15 --age-group=U16
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)