### PR TITLE
feat: QoP rankings scraper — model, scraper, and CLI command

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -15,6 +15,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Annotated, Literal, Optional
 
+import httpx
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -37,6 +38,7 @@ from src.models.audit import RunMetadata, RunSummary  # noqa: E402
 from src.scraper.config import ScrapingConfig  # noqa: E402
 from src.scraper.mls_scraper import MLSScraper, MLSScraperError  # noqa: E402
 from src.scraper.models import Match  # noqa: E402
+from src.scraper.qop_scraper import MLSQoPScraper  # noqa: E402
 from src.utils.audit_logger import AuditLogger  # noqa: E402
 from src.utils.division_lookup import get_division_id_for_league  # noqa: E402
 from src.utils.match_comparison import MatchComparison  # noqa: E402
@@ -2173,6 +2175,101 @@ def options() -> None:
     Displays available age groups, divisions, and usage examples.
     """
     config_options()
+
+
+@app.command()
+def rankings(
+    age_group: str = typer.Option(
+        "U14", "--age-group", "-a", help="Age group (e.g. U14)"
+    ),
+    division: str = typer.Option("Northeast", "--division", "-d", help="Division name"),
+    headless: bool = typer.Option(
+        True, "--headless/--no-headless", help="Run browser headless"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Scrape but do not POST to API"
+    ),
+    api_url: Optional[str] = typer.Option(
+        None, "--api-url", envvar="MISSING_TABLE_API_BASE_URL"
+    ),
+    api_token: Optional[str] = typer.Option(
+        None, "--api-token", envvar="MISSING_TABLE_API_TOKEN"
+    ),
+) -> None:
+    """Scrape QoP rankings from MLS Next and post to the MT API."""
+    setup_environment()
+
+    console.print(
+        f"[bold cyan]Scraping QoP rankings — {age_group} {division}...[/bold cyan]"
+    )
+
+    try:
+        scraper = MLSQoPScraper(
+            age_group=age_group, division=division, headless=headless
+        )
+        snapshot = asyncio.run(scraper.scrape())
+    except Exception as e:
+        console.print(f"[red]Scraping failed: {e}[/red]")
+        raise typer.Exit(code=1) from e
+
+    # Print Rich table
+    table = Table(
+        title=f"QoP Rankings — {snapshot.age_group} {snapshot.division} — Week of {snapshot.week_of}",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("Rank", style="dim", justify="right", width=6)
+    table.add_column("Team", min_width=24)
+    table.add_column("MP", justify="right", width=4)
+    table.add_column("Att", justify="right", width=6)
+    table.add_column("Def", justify="right", width=6)
+    table.add_column("QoP", justify="right", width=7)
+
+    for r in snapshot.rankings:
+        table.add_row(
+            str(r.rank),
+            r.team_name,
+            str(r.matches_played),
+            str(r.att_score),
+            str(r.def_score),
+            str(r.qop_score),
+        )
+
+    console.print(table)
+
+    if dry_run:
+        console.print("[yellow]Dry run — not posting to API[/yellow]")
+        return
+
+    if not api_token:
+        console.print(
+            "[red]Error: --api-token / MISSING_TABLE_API_TOKEN is required to POST rankings.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    base_url = api_url or "http://localhost:8000"
+    endpoint = f"{base_url}/api/qop-rankings"
+
+    try:
+        response = httpx.post(
+            endpoint,
+            json=snapshot.model_dump(mode="json"),
+            headers={"Authorization": f"Bearer {api_token}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        console.print(
+            f"[green]Posted {len(snapshot.rankings)} rankings to MT API"
+            f" for week of {snapshot.week_of} ✓[/green]"
+        )
+    except httpx.HTTPStatusError as e:
+        console.print(
+            f"[red]HTTP error posting rankings: {e.response.status_code} {e.response.text}[/red]"
+        )
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        console.print(f"[red]Failed to post rankings: {e}[/red]")
+        raise typer.Exit(code=1) from e
 
 
 @app.command()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,5 +4,6 @@ Pydantic models for data validation and serialization.
 
 from .discovery import DiscoveredClub, DiscoveredTeam
 from .match_data import MatchData
+from .qop_ranking import QoPRanking, QoPSnapshot
 
-__all__ = ["DiscoveredClub", "DiscoveredTeam", "MatchData"]
+__all__ = ["DiscoveredClub", "DiscoveredTeam", "MatchData", "QoPRanking", "QoPSnapshot"]

--- a/src/models/qop_ranking.py
+++ b/src/models/qop_ranking.py
@@ -1,0 +1,76 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class QoPRanking(BaseModel):
+    rank: int = Field(ge=1, description="Team's rank in the division")
+    team_name: str = Field(..., description="Full team name as displayed on MLS Next")
+    matches_played: int = Field(ge=0, description="Number of matches played")
+    att_score: float = Field(description="Attacking score")
+    def_score: float = Field(description="Defensive score")
+    qop_score: float = Field(description="Overall Quality of Play score")
+
+    @field_validator("team_name")
+    @classmethod
+    def strip_team_name(cls, v: str) -> str:
+        return v.strip()
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "rank": 1,
+                "team_name": "New York City FC",
+                "matches_played": 16,
+                "att_score": 89.6,
+                "def_score": 83.1,
+                "qop_score": 87.6,
+            }
+        }
+
+
+class QoPSnapshot(BaseModel):
+    """A full weekly snapshot for a division/age-group."""
+
+    week_of: date = Field(
+        description="ISO date of the Monday that starts the week this snapshot was taken"
+    )
+    division: str = Field(description="Division name, e.g. 'Northeast'")
+    age_group: str = Field(description="Age group, e.g. 'U14'")
+    scraped_at: datetime = Field(description="When the snapshot was taken")
+    rankings: list[QoPRanking] = Field(
+        default_factory=list, description="Ordered list of team rankings"
+    )
+
+    @field_validator("division")
+    @classmethod
+    def normalize_division(cls, v: str) -> str:
+        return v.strip().title()
+
+    @field_validator("age_group")
+    @classmethod
+    def normalize_age_group(cls, v: str) -> str:
+        v = v.strip()
+        if v.upper().startswith("U"):
+            return "U" + v[1:]
+        return v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "week_of": "2026-04-14",
+                "division": "Northeast",
+                "age_group": "U14",
+                "scraped_at": "2026-04-16T10:00:00Z",
+                "rankings": [
+                    {
+                        "rank": 1,
+                        "team_name": "New York City FC",
+                        "matches_played": 16,
+                        "att_score": 89.6,
+                        "def_score": 83.1,
+                        "qop_score": 87.6,
+                    }
+                ],
+            }
+        }

--- a/src/scraper/qop_scraper.py
+++ b/src/scraper/qop_scraper.py
@@ -1,0 +1,432 @@
+"""
+MLS Next QoP (Quality of Play) standings scraper.
+
+This module provides the MLSQoPScraper class that navigates to the MLS Next
+standings page, selects the appropriate division filter, and extracts team
+rankings from the standings table.
+"""
+
+import asyncio
+import re
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Optional
+
+from ..models.qop_ranking import QoPRanking, QoPSnapshot
+from ..utils.logger import get_logger
+from .browser import BrowserConfig, BrowserManager, PageNavigator
+from .consent_handler import MLSConsentHandler
+
+logger = get_logger()
+
+
+class QoPScraperError(Exception):
+    """Custom exception for QoP scraper failures."""
+
+    pass
+
+
+# Qualification status substrings that appear inline with team names on the page
+_QUALIFICATION_PATTERNS = re.compile(
+    r"(Championship Qualification|Premier Qualification|Qualification|Qualified)",
+    re.IGNORECASE,
+)
+
+
+def strip_qualification_text(raw: str) -> str:
+    """
+    Remove qualification status text from a raw team name string.
+
+    MLS Next standings pages render qualification labels (e.g. "Championship
+    Qualification", "Premier Qualification") as inline text adjacent to the
+    team name.  This function strips those substrings so only the club name
+    remains.
+
+    Args:
+        raw: Raw text extracted from the standings table team cell.
+
+    Returns:
+        Cleaned team name with leading/trailing whitespace removed.
+    """
+    cleaned = _QUALIFICATION_PATTERNS.sub("", raw)
+    # Collapse multiple internal spaces that may be left behind
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip()
+
+
+class MLSQoPScraper:
+    """
+    Scrapes MLS Next Quality-of-Play standings for a given age group and division.
+
+    Usage::
+
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        snapshot = await scraper.scrape()
+    """
+
+    # URL template: age_group "U14" → "u14"
+    MLS_STANDINGS_URL_TEMPLATE = (
+        "https://www.mlssoccer.com/mlsnext/standings/{age_slug}/"
+    )
+
+    # Retry configuration (mirrors MLSScraper)
+    MAX_RETRIES = 3
+    RETRY_DELAY_BASE = 1.0
+    RETRY_BACKOFF_MULTIPLIER = 2.0
+
+    # Selector timeout (ms)
+    DEFAULT_TIMEOUT = 10_000
+
+    def __init__(
+        self,
+        age_group: str,
+        division: str,
+        headless: bool = True,
+    ) -> None:
+        """
+        Initialize the QoP scraper.
+
+        Args:
+            age_group: Age group to scrape, e.g. "U14".
+            division:  Division label to select, e.g. "Northeast".
+                       Matched case-insensitively against options shown on the page.
+            headless:  Whether to run the browser in headless mode.
+        """
+        self.age_group = age_group
+        self.division = division
+        self.headless = headless
+        self.browser_manager: Optional[BrowserManager] = None
+
+        age_slug = age_group.lower()
+        self.standings_url = self.MLS_STANDINGS_URL_TEMPLATE.format(age_slug=age_slug)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def scrape(self) -> QoPSnapshot:
+        """
+        Navigate to the standings page, select the division filter, and extract
+        all team rankings.
+
+        Returns:
+            QoPSnapshot populated with the current standings data.
+
+        Raises:
+            QoPScraperError: If the scrape fails after all retries.
+        """
+        logger.info(
+            "Starting QoP standings scrape",
+            extra={
+                "age_group": self.age_group,
+                "division": self.division,
+                "url": self.standings_url,
+            },
+        )
+
+        last_exc: Optional[Exception] = None
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                snapshot = await self._scrape_attempt()
+                logger.info(
+                    "QoP standings scrape completed",
+                    extra={
+                        "age_group": self.age_group,
+                        "division": self.division,
+                        "rankings_count": len(snapshot.rankings),
+                        "attempt": attempt + 1,
+                    },
+                )
+                return snapshot
+
+            except QoPScraperError:
+                # Non-retryable logical errors (e.g. division not found) — re-raise immediately
+                raise
+
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "QoP scrape attempt failed",
+                    extra={
+                        "attempt": attempt + 1,
+                        "max_retries": self.MAX_RETRIES,
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+
+                if attempt < self.MAX_RETRIES - 1:
+                    delay = self._retry_delay(attempt)
+                    logger.info(
+                        "Retrying QoP scrape",
+                        extra={"delay_seconds": delay, "next_attempt": attempt + 2},
+                    )
+                    await asyncio.sleep(delay)
+
+            finally:
+                # Clean up browser between retries
+                if self.browser_manager:
+                    await self.browser_manager.cleanup()
+                    self.browser_manager = None
+
+        raise QoPScraperError(
+            f"QoP scrape failed after {self.MAX_RETRIES} attempts: {last_exc}"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _scrape_attempt(self) -> QoPSnapshot:
+        """Execute a single scrape attempt (browser init → navigate → extract)."""
+        # Initialise browser
+        browser_config = BrowserConfig(
+            headless=self.headless,
+            timeout=30_000,
+            viewport_width=1280,
+            viewport_height=720,
+        )
+        self.browser_manager = BrowserManager(browser_config)
+        await self.browser_manager.initialize()
+
+        async with self.browser_manager.get_page() as page:
+            await self._navigate(page)
+            await self._select_division(page)
+            rankings = await self._extract_rankings(page)
+
+        today = date.today()
+        week_of = today - timedelta(days=today.weekday())
+
+        return QoPSnapshot(
+            week_of=week_of,
+            division=self.division,
+            age_group=self.age_group,
+            scraped_at=datetime.now(tz=timezone.utc),
+            rankings=rankings,
+        )
+
+    async def _navigate(self, page: Any) -> None:
+        """Navigate to the standings URL and handle consent banners."""
+        logger.info("Navigating to standings page", extra={"url": self.standings_url})
+
+        navigator = PageNavigator(page, max_retries=self.MAX_RETRIES)
+        success = await navigator.navigate_to(self.standings_url, wait_until="load")
+        if not success:
+            raise QoPScraperError(
+                f"Failed to navigate to standings page: {self.standings_url}"
+            )
+
+        logger.info("Navigation successful — handling consent banner")
+        consent_handler = MLSConsentHandler(page)
+        consent_handled = await consent_handler.handle_consent_banner()
+        if not consent_handled:
+            logger.warning("Consent handling failed; continuing anyway")
+
+        page_ready = await consent_handler.wait_for_page_ready()
+        if not page_ready:
+            logger.warning("Page readiness check failed; continuing anyway")
+
+    async def _select_division(self, page: Any) -> None:
+        """
+        Find the division filter control on the page and select the target division.
+
+        The MLS Next standings page may expose the division filter as:
+          - A native <select> element
+          - A button-based dropdown (div/ul with clickable items)
+
+        We try the native select first, then fall back to button-based interaction.
+        """
+        target = self.division.lower()
+        logger.info("Selecting division filter", extra={"division": self.division})
+
+        # --- Strategy 1: native <select> element ---
+        selected = await self._try_select_element(page, target)
+        if selected:
+            logger.info("Division selected via <select> element")
+            await page.wait_for_timeout(1500)
+            return
+
+        # --- Strategy 2: clickable filter buttons / links ---
+        selected = await self._try_button_filter(page, target)
+        if selected:
+            logger.info("Division selected via button/link filter")
+            await page.wait_for_timeout(1500)
+            return
+
+        raise QoPScraperError(
+            f"Division filter not found for '{self.division}'. "
+            "The page structure may have changed or the division name is incorrect."
+        )
+
+    async def _try_select_element(self, page: Any, target_lower: str) -> bool:
+        """
+        Attempt to select the division using a native <select> dropdown.
+
+        Returns True if the division was successfully selected.
+        """
+        # Common selector patterns for MLS Next filter dropdowns
+        select_selectors = [
+            "select[name*='division']",
+            "select[id*='division']",
+            "select[class*='division']",
+            "select[name*='group']",
+            "select[id*='group']",
+            "select",  # broad fallback — iterate all selects
+        ]
+
+        for sel in select_selectors:
+            try:
+                select_elements = await page.query_selector_all(sel)
+                for select_el in select_elements:
+                    options = await select_el.query_selector_all("option")
+                    for option in options:
+                        text = await option.text_content() or ""
+                        if target_lower in text.lower():
+                            value = await option.get_attribute("value") or text.strip()
+                            await select_el.select_option(value=value)
+                            return True
+            except Exception as exc:
+                logger.debug(
+                    "select_element attempt failed",
+                    extra={"selector": sel, "error": str(exc)},
+                )
+
+        return False
+
+    async def _try_button_filter(self, page: Any, target_lower: str) -> bool:
+        """
+        Attempt to select the division by clicking a button or link that contains
+        the division name.
+
+        Returns True if the division was successfully selected.
+        """
+        # Selectors for MLS Next filter pill/button patterns
+        button_selectors = [
+            f"button:has-text('{self.division}')",
+            f"a:has-text('{self.division}')",
+            f"[data-value*='{self.division}']",
+            f"[data-filter*='{self.division}']",
+        ]
+
+        for sel in button_selectors:
+            try:
+                el = await page.query_selector(sel)
+                if el:
+                    await el.click()
+                    return True
+            except Exception:
+                pass
+
+        # Broader search: find any clickable element whose visible text contains
+        # the division name (case-insensitive)
+        try:
+            candidates = await page.query_selector_all(
+                "button, a, [role='option'], [role='button'], li"
+            )
+            for el in candidates:
+                text = await el.text_content() or ""
+                if target_lower in text.lower() and "division" in text.lower():
+                    await el.click()
+                    return True
+        except Exception as exc:
+            logger.debug("Broad button filter search failed", extra={"error": str(exc)})
+
+        return False
+
+    async def _extract_rankings(self, page: Any) -> list[QoPRanking]:
+        """
+        Wait for the standings table and extract all rows.
+
+        Returns:
+            List of QoPRanking objects ordered by rank.
+        """
+        logger.info("Waiting for standings table")
+
+        # Try multiple table selectors
+        table_selectors = [
+            "table tbody tr",
+            "tbody tr",
+            "[class*='standings'] tr",
+            "[class*='table'] tr",
+            "tr",
+        ]
+
+        rows = []
+        for sel in table_selectors:
+            try:
+                await page.wait_for_selector(sel, timeout=self.DEFAULT_TIMEOUT)
+                rows = await page.query_selector_all(sel)
+                if rows:
+                    logger.info(
+                        "Found standings rows",
+                        extra={"selector": sel, "row_count": len(rows)},
+                    )
+                    break
+            except Exception:
+                continue
+
+        if not rows:
+            raise QoPScraperError(
+                "Could not locate standings table rows on the page. "
+                "The page structure may have changed."
+            )
+
+        rankings: list[QoPRanking] = []
+        skipped = 0
+
+        for row in rows:
+            cells = await row.query_selector_all("td")
+            if len(cells) < 6:
+                # Skip header rows or malformed rows
+                skipped += 1
+                continue
+
+            try:
+                rank_text = (await cells[0].text_content() or "").strip()
+                team_raw = (await cells[1].text_content() or "").strip()
+                mp_text = (await cells[2].text_content() or "").strip()
+                att_text = (await cells[3].text_content() or "").strip()
+                def_text = (await cells[4].text_content() or "").strip()
+                qop_text = (await cells[5].text_content() or "").strip()
+
+                rank = int(rank_text)
+                team_name = strip_qualification_text(team_raw)
+                matches_played = int(mp_text)
+                att_score = float(att_text)
+                def_score = float(def_text)
+                qop_score = float(qop_text)
+
+                rankings.append(
+                    QoPRanking(
+                        rank=rank,
+                        team_name=team_name,
+                        matches_played=matches_played,
+                        att_score=att_score,
+                        def_score=def_score,
+                        qop_score=qop_score,
+                    )
+                )
+
+            except (ValueError, IndexError) as exc:
+                skipped += 1
+                logger.debug(
+                    "Skipping unparseable standings row",
+                    extra={"error": str(exc)},
+                )
+
+        logger.info(
+            "Standings extraction complete",
+            extra={"parsed_rows": len(rankings), "skipped_rows": skipped},
+        )
+
+        if not rankings:
+            raise QoPScraperError(
+                "No rankings could be extracted from the standings table. "
+                "Check that the correct division is selected and the page rendered."
+            )
+
+        return rankings
+
+    def _retry_delay(self, attempt: int) -> float:
+        """Calculate exponential backoff delay for a given attempt (0-based)."""
+        return self.RETRY_DELAY_BASE * (self.RETRY_BACKOFF_MULTIPLIER**attempt)

--- a/tests/unit/test_qop_ranking.py
+++ b/tests/unit/test_qop_ranking.py
@@ -1,0 +1,137 @@
+"""Unit tests for QoPRanking and QoPSnapshot models."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.qop_ranking import QoPRanking, QoPSnapshot
+
+
+@pytest.mark.unit
+class TestQoPRanking:
+    """Test cases for QoPRanking Pydantic model."""
+
+    def test_valid_construction(self):
+        ranking = QoPRanking(
+            rank=1,
+            team_name="New York City FC",
+            matches_played=16,
+            att_score=89.6,
+            def_score=83.1,
+            qop_score=87.6,
+        )
+
+        assert ranking.rank == 1
+        assert ranking.team_name == "New York City FC"
+        assert ranking.matches_played == 16
+        assert ranking.att_score == 89.6
+        assert ranking.def_score == 83.1
+        assert ranking.qop_score == 87.6
+
+    def test_rank_must_be_at_least_one(self):
+        with pytest.raises(ValidationError):
+            QoPRanking(
+                rank=0,
+                team_name="New York City FC",
+                matches_played=16,
+                att_score=89.6,
+                def_score=83.1,
+                qop_score=87.6,
+            )
+
+    def test_matches_played_cannot_be_negative(self):
+        with pytest.raises(ValidationError):
+            QoPRanking(
+                rank=1,
+                team_name="New York City FC",
+                matches_played=-1,
+                att_score=89.6,
+                def_score=83.1,
+                qop_score=87.6,
+            )
+
+    def test_team_name_whitespace_is_stripped(self):
+        ranking = QoPRanking(
+            rank=1,
+            team_name="  New York City FC  ",
+            matches_played=16,
+            att_score=89.6,
+            def_score=83.1,
+            qop_score=87.6,
+        )
+
+        assert ranking.team_name == "New York City FC"
+
+
+@pytest.mark.unit
+class TestQoPSnapshot:
+    """Test cases for QoPSnapshot Pydantic model."""
+
+    def _make_ranking(self, rank: int = 1) -> QoPRanking:
+        return QoPRanking(
+            rank=rank,
+            team_name="New York City FC",
+            matches_played=16,
+            att_score=89.6,
+            def_score=83.1,
+            qop_score=87.6,
+        )
+
+    def test_valid_construction(self):
+        snapshot = QoPSnapshot(
+            week_of=date(2026, 4, 14),
+            division="Northeast",
+            age_group="U14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+            rankings=[self._make_ranking()],
+        )
+
+        assert snapshot.week_of == date(2026, 4, 14)
+        assert snapshot.division == "Northeast"
+        assert snapshot.age_group == "U14"
+        assert len(snapshot.rankings) == 1
+
+    def test_division_normalized_to_title_case(self):
+        snapshot = QoPSnapshot(
+            week_of=date(2026, 4, 14),
+            division="northeast",
+            age_group="U14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert snapshot.division == "Northeast"
+
+    def test_age_group_normalized(self):
+        snapshot = QoPSnapshot(
+            week_of=date(2026, 4, 14),
+            division="Northeast",
+            age_group="u14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert snapshot.age_group == "U14"
+
+    def test_rankings_default_to_empty_list(self):
+        snapshot = QoPSnapshot(
+            week_of=date(2026, 4, 14),
+            division="Northeast",
+            age_group="U14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert snapshot.rankings == []
+
+    def test_json_serialization_round_trip(self):
+        original = QoPSnapshot(
+            week_of=date(2026, 4, 14),
+            division="Northeast",
+            age_group="U14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+            rankings=[self._make_ranking(rank=1), self._make_ranking(rank=2)],
+        )
+
+        data = original.model_dump(mode="json")
+        restored = QoPSnapshot.model_validate(data)
+
+        assert restored == original

--- a/tests/unit/test_qop_scraper.py
+++ b/tests/unit/test_qop_scraper.py
@@ -1,0 +1,720 @@
+"""Unit tests for MLSQoPScraper and related helpers."""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.models.qop_ranking import QoPRanking, QoPSnapshot
+from src.scraper.qop_scraper import (
+    MLSQoPScraper,
+    QoPScraperError,
+    strip_qualification_text,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function tests — no mocking needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStripQualificationText:
+    """Tests for the strip_qualification_text() helper."""
+
+    def test_plain_name_unchanged(self):
+        assert strip_qualification_text("New York City FC") == "New York City FC"
+
+    def test_championship_qualification_removed(self):
+        raw = "New York City FCChampionship Qualification"
+        assert strip_qualification_text(raw) == "New York City FC"
+
+    def test_premier_qualification_removed(self):
+        raw = "FC Dallas Premier Qualification"
+        assert strip_qualification_text(raw) == "FC Dallas"
+
+    def test_bare_qualification_removed(self):
+        raw = "LA Galaxy Qualification"
+        assert strip_qualification_text(raw) == "LA Galaxy"
+
+    def test_case_insensitive_removal(self):
+        raw = "Chicago Fire FC championship qualification"
+        assert strip_qualification_text(raw) == "Chicago Fire FC"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        assert strip_qualification_text("  Real Salt Lake  ") == "Real Salt Lake"
+
+    def test_empty_string(self):
+        assert strip_qualification_text("") == ""
+
+    def test_multiple_spaces_collapsed(self):
+        # After stripping "Qualification" internal spaces should be collapsed
+        raw = "Portland  Timbers  Qualification"
+        result = strip_qualification_text(raw)
+        assert "  " not in result
+        assert "Portland" in result
+        assert "Timbers" in result
+
+
+# ---------------------------------------------------------------------------
+# week_of logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWeekOf:
+    """Verify the week_of calculation always lands on a Monday."""
+
+    def test_week_of_is_monday(self):
+        """Regardless of when tests run, week_of must be the Monday of current week."""
+        today = date.today()
+        expected_monday = today - timedelta(days=today.weekday())
+        # Simulate what the scraper does
+        computed = today - timedelta(days=today.weekday())
+        assert computed == expected_monday
+        assert computed.weekday() == 0  # 0 == Monday
+
+    def test_week_of_is_not_in_future(self):
+        today = date.today()
+        week_of = today - timedelta(days=today.weekday())
+        assert week_of <= today
+
+
+# ---------------------------------------------------------------------------
+# QoPScraperError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestQoPScraperError:
+    def test_is_exception(self):
+        err = QoPScraperError("boom")
+        assert isinstance(err, Exception)
+        assert str(err) == "boom"
+
+    def test_chaining(self):
+        original = ValueError("root cause")
+        try:
+            raise QoPScraperError("wrapper") from original
+        except QoPScraperError as exc:
+            assert exc.__cause__ is original
+
+
+# ---------------------------------------------------------------------------
+# MLSQoPScraper initialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMLSQoPScraperInit:
+    def test_url_built_correctly_for_u14(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        assert "u14" in scraper.standings_url
+        assert scraper.standings_url.startswith("https://")
+
+    def test_url_built_correctly_for_u16(self):
+        scraper = MLSQoPScraper(age_group="U16", division="Southeast")
+        assert "u16" in scraper.standings_url
+
+    def test_attributes_stored(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast", headless=False)
+        assert scraper.age_group == "U14"
+        assert scraper.division == "Northeast"
+        assert scraper.headless is False
+
+    def test_retry_constants_exist(self):
+        assert MLSQoPScraper.MAX_RETRIES == 3
+        assert MLSQoPScraper.RETRY_DELAY_BASE > 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking the Playwright page
+# ---------------------------------------------------------------------------
+
+
+def _make_cell(text: str) -> AsyncMock:
+    """Create a mock <td> element that returns *text* from text_content()."""
+    cell = AsyncMock()
+    cell.text_content = AsyncMock(return_value=text)
+    return cell
+
+
+def _make_row(rank, team, mp, att, def_, qop) -> AsyncMock:
+    """Create a mock <tr> element with 6 <td> cells."""
+    row = AsyncMock()
+    cells = [
+        _make_cell(str(rank)),
+        _make_cell(team),
+        _make_cell(str(mp)),
+        _make_cell(str(att)),
+        _make_cell(str(def_)),
+        _make_cell(str(qop)),
+    ]
+    row.query_selector_all = AsyncMock(return_value=cells)
+    return row
+
+
+def _make_short_row() -> AsyncMock:
+    """Create a row with too few cells (header-like)."""
+    row = AsyncMock()
+    row.query_selector_all = AsyncMock(return_value=[_make_cell("Rank")])
+    return row
+
+
+# ---------------------------------------------------------------------------
+# _extract_rankings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractRankings:
+    """Tests for MLSQoPScraper._extract_rankings() in isolation."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_extracts_valid_rows(self, scraper):
+        page = AsyncMock()
+
+        rows = [
+            _make_short_row(),  # header — should be skipped
+            _make_row(1, "New York City FC", 16, 89.6, 83.1, 87.6),
+            _make_row(2, "FC Dallas", 15, 78.2, 75.0, 77.1),
+        ]
+
+        page.wait_for_selector = AsyncMock(return_value=None)
+        page.query_selector_all = AsyncMock(return_value=rows)
+
+        rankings = await scraper._extract_rankings(page)
+
+        assert len(rankings) == 2
+        assert rankings[0].rank == 1
+        assert rankings[0].team_name == "New York City FC"
+        assert rankings[0].qop_score == pytest.approx(87.6)
+        assert rankings[1].rank == 2
+
+    @pytest.mark.asyncio
+    async def test_strips_qualification_text_from_team_name(self, scraper):
+        page = AsyncMock()
+
+        rows = [
+            _make_row(
+                1,
+                "New York City FCChampionship Qualification",
+                14,
+                90.0,
+                80.0,
+                85.0,
+            )
+        ]
+
+        page.wait_for_selector = AsyncMock(return_value=None)
+        page.query_selector_all = AsyncMock(return_value=rows)
+
+        rankings = await scraper._extract_rankings(page)
+
+        assert len(rankings) == 1
+        assert rankings[0].team_name == "New York City FC"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_rows_found(self, scraper):
+        page = AsyncMock()
+        page.wait_for_selector = AsyncMock(side_effect=Exception("timeout"))
+        page.query_selector_all = AsyncMock(return_value=[])
+
+        with pytest.raises(QoPScraperError, match="standings table rows"):
+            await scraper._extract_rankings(page)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_all_rows_unparseable(self, scraper):
+        page = AsyncMock()
+
+        bad_row = AsyncMock()
+        bad_row.query_selector_all = AsyncMock(
+            return_value=[
+                _make_cell("foo"),
+                _make_cell("bar"),
+                _make_cell("baz"),
+                _make_cell("qux"),
+                _make_cell("quux"),
+                _make_cell("corge"),
+            ]
+        )
+
+        page.wait_for_selector = AsyncMock(return_value=None)
+        page.query_selector_all = AsyncMock(return_value=[bad_row])
+
+        with pytest.raises(QoPScraperError, match="No rankings could be extracted"):
+            await scraper._extract_rankings(page)
+
+
+# ---------------------------------------------------------------------------
+# Division filter not found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSelectDivision:
+    """Tests for MLSQoPScraper._select_division() edge cases."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_division_not_found(self, scraper):
+        """_select_division must raise QoPScraperError if no filter matches."""
+        page = AsyncMock()
+        # All strategies return nothing useful
+        page.query_selector_all = AsyncMock(return_value=[])
+        page.query_selector = AsyncMock(return_value=None)
+        page.wait_for_timeout = AsyncMock(return_value=None)
+
+        with pytest.raises(QoPScraperError, match="Division filter not found"):
+            await scraper._select_division(page)
+
+    @pytest.mark.asyncio
+    async def test_selects_via_native_select_element(self, scraper):
+        """_try_select_element should select the matching option."""
+        page = AsyncMock()
+
+        option = AsyncMock()
+        option.text_content = AsyncMock(return_value="Northeast Division")
+        option.get_attribute = AsyncMock(return_value="northeast-division")
+
+        select_el = AsyncMock()
+        select_el.query_selector_all = AsyncMock(return_value=[option])
+        select_el.select_option = AsyncMock(return_value=None)
+
+        # Return select_el for the first broad "select" query
+        page.query_selector_all = AsyncMock(return_value=[select_el])
+        page.query_selector = AsyncMock(return_value=None)
+        page.wait_for_timeout = AsyncMock(return_value=None)
+
+        # Should not raise
+        await scraper._select_division(page)
+
+        select_el.select_option.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Full scrape() — integration-level mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMLSQoPScraperScrape:
+    """Tests for the top-level scrape() method using heavily mocked internals."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_scrape_returns_snapshot(self, scraper):
+        """A successful scrape should return a valid QoPSnapshot."""
+        fake_rankings = [
+            QoPRanking(
+                rank=1,
+                team_name="Club A",
+                matches_played=10,
+                att_score=85.0,
+                def_score=80.0,
+                qop_score=83.0,
+            )
+        ]
+
+        with (
+            patch.object(
+                scraper, "_scrape_attempt", new_callable=AsyncMock
+            ) as mock_attempt,
+        ):
+            today = date.today()
+            week_of = today - timedelta(days=today.weekday())
+            from datetime import datetime, timezone
+
+            mock_attempt.return_value = QoPSnapshot(
+                week_of=week_of,
+                division="Northeast",
+                age_group="U14",
+                scraped_at=datetime.now(tz=timezone.utc),
+                rankings=fake_rankings,
+            )
+
+            snapshot = await scraper.scrape()
+
+        assert isinstance(snapshot, QoPSnapshot)
+        assert snapshot.age_group == "U14"
+        assert snapshot.division == "Northeast"
+        assert len(snapshot.rankings) == 1
+        assert snapshot.rankings[0].team_name == "Club A"
+        assert snapshot.week_of.weekday() == 0  # Monday
+
+    @pytest.mark.asyncio
+    async def test_scrape_reraises_qop_scraper_error_immediately(self, scraper):
+        """QoPScraperError (logical errors) should not be retried."""
+        call_count = 0
+
+        async def failing_attempt():
+            nonlocal call_count
+            call_count += 1
+            raise QoPScraperError("Division not found")
+
+        with patch.object(scraper, "_scrape_attempt", side_effect=failing_attempt):
+            with pytest.raises(QoPScraperError, match="Division not found"):
+                await scraper.scrape()
+
+        # Should fail on first attempt without retrying
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_scrape_retries_on_generic_exception(self, scraper):
+        """Generic exceptions should trigger retries up to MAX_RETRIES."""
+        call_count = 0
+
+        async def always_fails():
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("network error")
+
+        with (
+            patch.object(scraper, "_scrape_attempt", side_effect=always_fails),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(QoPScraperError):
+                await scraper.scrape()
+
+    @pytest.mark.asyncio
+    async def test_browser_manager_cleaned_up_after_failure(self, scraper):
+        """browser_manager.cleanup() must be called even when _scrape_attempt raises."""
+        mock_bm = AsyncMock()
+        mock_bm.cleanup = AsyncMock()
+
+        async def failing_attempt():
+            scraper.browser_manager = mock_bm
+            raise RuntimeError("boom")
+
+        with (
+            patch.object(scraper, "_scrape_attempt", side_effect=failing_attempt),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(QoPScraperError):
+                await scraper.scrape()
+
+        mock_bm.cleanup.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _scrape_attempt  (mocking BrowserManager)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScrapeAttempt:
+    """Tests for MLSQoPScraper._scrape_attempt() with BrowserManager mocked."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_scrape_attempt_returns_snapshot(self, scraper):
+        """_scrape_attempt should initialise browser, call sub-methods, build QoPSnapshot."""
+        real_ranking = __import__(
+            "src.models.qop_ranking", fromlist=["QoPRanking"]
+        ).QoPRanking(
+            rank=1,
+            team_name="FC Test",
+            matches_played=12,
+            att_score=80.0,
+            def_score=75.0,
+            qop_score=78.0,
+        )
+
+        mock_page = AsyncMock()
+        mock_page.wait_for_timeout = AsyncMock()
+
+        # Build a mock BrowserManager whose get_page() context manager yields mock_page
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _fake_get_page():
+            yield mock_page
+
+        mock_bm = AsyncMock()
+        mock_bm.initialize = AsyncMock()
+        mock_bm.get_page = _fake_get_page
+        mock_bm.cleanup = AsyncMock()
+
+        with (
+            patch("src.scraper.qop_scraper.BrowserManager", return_value=mock_bm),
+            patch("src.scraper.qop_scraper.BrowserConfig"),
+            patch.object(scraper, "_navigate", new_callable=AsyncMock),
+            patch.object(scraper, "_select_division", new_callable=AsyncMock),
+            patch.object(
+                scraper,
+                "_extract_rankings",
+                new_callable=AsyncMock,
+                return_value=[real_ranking],
+            ),
+        ):
+            snapshot = await scraper._scrape_attempt()
+
+        assert isinstance(snapshot, QoPSnapshot)
+        assert snapshot.age_group == "U14"
+        assert snapshot.division == "Northeast"
+        assert snapshot.week_of.weekday() == 0  # Monday
+        assert len(snapshot.rankings) == 1
+        mock_bm.initialize.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _navigate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNavigate:
+    """Tests for MLSQoPScraper._navigate()."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_navigate_success(self, scraper):
+        """Successful navigation calls consent handler and page ready check."""
+        page = AsyncMock()
+
+        mock_navigator = AsyncMock()
+        mock_navigator.navigate_to = AsyncMock(return_value=True)
+
+        mock_consent = AsyncMock()
+        mock_consent.handle_consent_banner = AsyncMock(return_value=True)
+        mock_consent.wait_for_page_ready = AsyncMock(return_value=True)
+
+        with (
+            patch("src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator),
+            patch(
+                "src.scraper.qop_scraper.MLSConsentHandler", return_value=mock_consent
+            ),
+        ):
+            await scraper._navigate(page)
+
+        mock_navigator.navigate_to.assert_called_once()
+        mock_consent.handle_consent_banner.assert_called_once()
+        mock_consent.wait_for_page_ready.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_navigate_raises_on_navigation_failure(self, scraper):
+        """Should raise QoPScraperError when navigate_to returns False."""
+        page = AsyncMock()
+
+        mock_navigator = AsyncMock()
+        mock_navigator.navigate_to = AsyncMock(return_value=False)
+
+        with patch(
+            "src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator
+        ):
+            with pytest.raises(QoPScraperError, match="Failed to navigate"):
+                await scraper._navigate(page)
+
+    @pytest.mark.asyncio
+    async def test_navigate_continues_when_consent_fails(self, scraper):
+        """A failed consent banner should not raise — just log a warning."""
+        page = AsyncMock()
+
+        mock_navigator = AsyncMock()
+        mock_navigator.navigate_to = AsyncMock(return_value=True)
+
+        mock_consent = AsyncMock()
+        mock_consent.handle_consent_banner = AsyncMock(return_value=False)
+        mock_consent.wait_for_page_ready = AsyncMock(return_value=False)
+
+        with (
+            patch("src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator),
+            patch(
+                "src.scraper.qop_scraper.MLSConsentHandler", return_value=mock_consent
+            ),
+        ):
+            # Should not raise despite consent + readiness failures
+            await scraper._navigate(page)
+
+
+# ---------------------------------------------------------------------------
+# _try_button_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTryButtonFilter:
+    """Tests for MLSQoPScraper._try_button_filter()."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_direct_selector_matches(self, scraper):
+        """Should click and return True when query_selector finds a matching element."""
+        page = AsyncMock()
+        mock_el = AsyncMock()
+        mock_el.click = AsyncMock()
+
+        # First selector (button:has-text) hits
+        page.query_selector = AsyncMock(return_value=mock_el)
+        page.query_selector_all = AsyncMock(return_value=[])
+
+        result = await scraper._try_button_filter(page, "northeast")
+
+        assert result is True
+        mock_el.click.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_true_via_broad_candidate_search(self, scraper):
+        """Should find a matching element via the broad candidate fallback."""
+        page = AsyncMock()
+        # Direct selectors find nothing
+        page.query_selector = AsyncMock(return_value=None)
+
+        # Candidate element whose text matches "northeast division"
+        candidate = AsyncMock()
+        candidate.text_content = AsyncMock(return_value="Northeast Division")
+        candidate.click = AsyncMock()
+
+        page.query_selector_all = AsyncMock(return_value=[candidate])
+
+        result = await scraper._try_button_filter(page, "northeast")
+
+        assert result is True
+        candidate.click.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_match(self, scraper):
+        """Should return False when nothing matches."""
+        page = AsyncMock()
+        page.query_selector = AsyncMock(return_value=None)
+
+        non_matching = AsyncMock()
+        non_matching.text_content = AsyncMock(return_value="Unrelated Text")
+
+        page.query_selector_all = AsyncMock(return_value=[non_matching])
+
+        result = await scraper._try_button_filter(page, "northeast")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_broad_search_exception(self, scraper):
+        """Should return False (not raise) if query_selector_all itself throws."""
+        page = AsyncMock()
+        page.query_selector = AsyncMock(return_value=None)
+        page.query_selector_all = AsyncMock(side_effect=RuntimeError("dom error"))
+
+        result = await scraper._try_button_filter(page, "northeast")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_rankings — secondary selector fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractRankingsFallback:
+    """Tests for selector fallback logic in _extract_rankings."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_second_selector_when_first_times_out(self, scraper):
+        """First table selector timing out should cause the loop to try the next one."""
+        page = AsyncMock()
+
+        good_row = _make_row(1, "Club A", 10, 80.0, 75.0, 78.0)
+
+        call_count = 0
+
+        async def wait_for_selector_stub(sel, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("timeout")
+            # Second selector succeeds
+            return None
+
+        page.wait_for_selector = wait_for_selector_stub
+        page.query_selector_all = AsyncMock(return_value=[good_row])
+
+        rankings = await scraper._extract_rankings(page)
+
+        assert len(rankings) == 1
+        assert call_count >= 2  # at least two selector attempts
+
+    @pytest.mark.asyncio
+    async def test_select_division_button_path_called(self, scraper):
+        """_select_division takes the button path when _try_select_element returns False."""
+        page = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+
+        with (
+            patch.object(
+                scraper,
+                "_try_select_element",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                scraper,
+                "_try_button_filter",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_btn,
+        ):
+            await scraper._select_division(page)
+
+        mock_btn.assert_called_once()
+        page.wait_for_timeout.assert_called_once_with(1500)
+
+
+# ---------------------------------------------------------------------------
+# Exception-handler branches in _try_select_element and _try_button_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExceptionHandlerBranches:
+    """Cover the except branches that swallow errors and try the next selector."""
+
+    @pytest.fixture
+    def scraper(self):
+        return MLSQoPScraper(age_group="U14", division="Northeast")
+
+    @pytest.mark.asyncio
+    async def test_try_select_element_handles_query_selector_all_exception(
+        self, scraper
+    ):
+        """When query_selector_all raises, the loop should continue and return False."""
+        page = AsyncMock()
+        # Make every query_selector_all call raise so all selectors are exhausted
+        page.query_selector_all = AsyncMock(side_effect=RuntimeError("dom error"))
+
+        result = await scraper._try_select_element(page, "northeast")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_try_button_filter_handles_query_selector_exception(self, scraper):
+        """When query_selector raises, the specific-selector loop continues."""
+        page = AsyncMock()
+        # Direct selectors raise; broad fallback returns empty
+        page.query_selector = AsyncMock(side_effect=RuntimeError("boom"))
+        page.query_selector_all = AsyncMock(return_value=[])
+
+        result = await scraper._try_button_filter(page, "northeast")
+
+        assert result is False

--- a/tests/unit/test_rankings_command.py
+++ b/tests/unit/test_rankings_command.py
@@ -1,0 +1,329 @@
+"""Unit tests for the `rankings` CLI command."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from src.cli.main import app
+from src.models.qop_ranking import QoPRanking, QoPSnapshot
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+runner = CliRunner()
+
+
+def _make_snapshot() -> QoPSnapshot:
+    """Build a minimal QoPSnapshot for use in tests."""
+    return QoPSnapshot(
+        week_of=date(2026, 4, 13),
+        division="Northeast",
+        age_group="U14",
+        scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+        rankings=[
+            QoPRanking(
+                rank=1,
+                team_name="New York City FC",
+                matches_played=16,
+                att_score=89.6,
+                def_score=83.1,
+                qop_score=87.6,
+            ),
+            QoPRanking(
+                rank=2,
+                team_name="New England Revolution",
+                matches_played=15,
+                att_score=78.4,
+                def_score=81.2,
+                qop_score=79.5,
+            ),
+        ],
+    )
+
+
+def _mock_scraper(snapshot: QoPSnapshot):
+    """Return a patched MLSQoPScraper whose scrape() returns the given snapshot."""
+    mock_instance = MagicMock()
+    mock_instance.scrape = AsyncMock(return_value=snapshot)
+    return mock_instance
+
+
+# ---------------------------------------------------------------------------
+# Test: --dry-run flag
+# ---------------------------------------------------------------------------
+
+
+class TestRankingsDryRun:
+    """Tests for the --dry-run flag behaviour."""
+
+    def test_dry_run_does_not_call_http(self):
+        """Dry-run should scrape but skip the HTTP POST entirely."""
+        snapshot = _make_snapshot()
+        mock_scraper_instance = _mock_scraper(snapshot)
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=mock_scraper_instance,
+            ) as MockScraper,
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            result = runner.invoke(app, ["rankings", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        MockScraper.assert_called_once_with(
+            age_group="U14", division="Northeast", headless=True
+        )
+        mock_scraper_instance.scrape.assert_called_once()
+        mock_httpx.post.assert_not_called()
+
+    def test_dry_run_prints_table(self):
+        """Dry-run output should include the team names from the snapshot."""
+        snapshot = _make_snapshot()
+
+        with patch(
+            "src.cli.main.MLSQoPScraper",
+            return_value=_mock_scraper(snapshot),
+        ):
+            result = runner.invoke(app, ["rankings", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "New York City FC" in result.output
+
+    def test_dry_run_prints_dry_run_message(self):
+        """The 'Dry run' notice should appear in the output."""
+        snapshot = _make_snapshot()
+
+        with patch(
+            "src.cli.main.MLSQoPScraper",
+            return_value=_mock_scraper(snapshot),
+        ):
+            result = runner.invoke(app, ["rankings", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Test: missing API token
+# ---------------------------------------------------------------------------
+
+
+class TestRankingsMissingToken:
+    """Tests for the case where no API token is provided."""
+
+    def test_missing_token_exits_with_code_1(self, monkeypatch):
+        """Command should exit 1 if no token is set and --dry-run is not used."""
+        snapshot = _make_snapshot()
+        monkeypatch.delenv("MISSING_TABLE_API_TOKEN", raising=False)
+
+        with patch(
+            "src.cli.main.MLSQoPScraper",
+            return_value=_mock_scraper(snapshot),
+        ):
+            result = runner.invoke(
+                app,
+                ["rankings"],
+                env={"MISSING_TABLE_API_TOKEN": ""},
+            )
+
+        assert result.exit_code == 1
+
+    def test_missing_token_prints_error_message(self, monkeypatch):
+        """An informative error should appear when the token is absent."""
+        snapshot = _make_snapshot()
+        monkeypatch.delenv("MISSING_TABLE_API_TOKEN", raising=False)
+
+        with patch(
+            "src.cli.main.MLSQoPScraper",
+            return_value=_mock_scraper(snapshot),
+        ):
+            result = runner.invoke(
+                app,
+                ["rankings"],
+                env={"MISSING_TABLE_API_TOKEN": ""},
+            )
+
+        assert "api-token" in result.output.lower() or "token" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: successful POST
+# ---------------------------------------------------------------------------
+
+
+class TestRankingsSuccessfulPost:
+    """Tests for the happy-path POST to the MT API."""
+
+    def test_post_called_with_correct_headers(self):
+        """httpx.post should be called with the Authorization header."""
+        snapshot = _make_snapshot()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception  # prevent isinstance check issues
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "test-secret",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_httpx.post.assert_called_once()
+        call_kwargs = mock_httpx.post.call_args
+        assert call_kwargs.kwargs["headers"] == {"Authorization": "Bearer test-secret"}
+
+    def test_post_called_with_correct_url(self):
+        """httpx.post should target /api/qop-rankings on the given base URL."""
+        snapshot = _make_snapshot()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        url_arg = mock_httpx.post.call_args.args[0]
+        assert url_arg == "http://api.example.com/api/qop-rankings"
+
+    def test_post_body_is_snapshot_json(self):
+        """The POST body should be the full snapshot serialised as JSON."""
+        snapshot = _make_snapshot()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        posted_json = mock_httpx.post.call_args.kwargs["json"]
+        assert posted_json["age_group"] == "U14"
+        assert posted_json["division"] == "Northeast"
+        assert len(posted_json["rankings"]) == 2
+
+    def test_success_message_printed(self):
+        """A success message including the ranking count should be printed."""
+        snapshot = _make_snapshot()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "2" in result.output  # ranking count
+        assert "2026-04-13" in result.output  # week_of date
+
+
+# ---------------------------------------------------------------------------
+# Test: HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+class TestRankingsHttpError:
+    """Tests for HTTP error responses from the API."""
+
+    def test_http_error_exits_code_1(self):
+        """An HTTP error response should cause exit code 1."""
+        import httpx as real_httpx
+
+        snapshot = _make_snapshot()
+
+        # Build a real HTTPStatusError so isinstance checks work
+        mock_request = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        http_err = real_httpx.HTTPStatusError(
+            "500", request=mock_request, response=mock_resp
+        )
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx.post", side_effect=http_err),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- Adds `QoPRanking` and `QoPSnapshot` Pydantic models (`src/models/qop_ranking.py`) for representing weekly MLS Next Quality of Play ranking snapshots
- Adds `MLSQoPScraper` (`src/scraper/qop_scraper.py`) — Playwright-based scraper that navigates to the MLS Next standings page, selects the target division, and extracts all ranking rows
- Adds `mls-scraper rankings` CLI command — scrapes QoP data, prints a Rich table, and POSTs the snapshot to the MT API

## Issues closed
Closes #58, #59, #60

## Usage
```bash
# Dry run (scrape only, no POST)
mls-scraper rankings --age-group u14 --division northeast --dry-run

# Full run
mls-scraper rankings --age-group u14 --division northeast
```

## Test plan
- [ ] All new unit tests pass: `pytest tests/unit/test_qop_ranking.py tests/unit/test_qop_scraper.py tests/unit/test_rankings_command.py`
- [ ] Smoke test against live page: `mls-scraper rankings --age-group u14 --division northeast --no-headless --dry-run`
- [ ] Verify Rich table output matches expected columns (Rank, Team, MP, Att, Def, QoP)

## Merge order
Merge this before `missing-table` and `match-scraper-agent` so the updated library is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)