### PR TITLE
fix: Rewrite QoP scraper to use modular11 HTTP endpoint

### DIFF
--- a/src/scraper/qop_scraper.py
+++ b/src/scraper/qop_scraper.py
@@ -1,20 +1,23 @@
 """
 MLS Next QoP (Quality of Play) standings scraper.
 
-This module provides the MLSQoPScraper class that navigates to the MLS Next
-standings page, selects the appropriate division filter, and extracts team
-rankings from the standings table.
+Fetches standings directly from the modular11 HTTP endpoint that the MLS Next
+standings iframe uses internally. No browser automation required — the endpoint
+returns an HTML fragment with rankings for every division in the given age
+group, and we parse the target division with BeautifulSoup.
 """
+
+from __future__ import annotations
 
 import asyncio
 import re
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Optional
+
+import httpx
+from bs4 import BeautifulSoup, Tag
 
 from ..models.qop_ranking import QoPRanking, QoPSnapshot
 from ..utils.logger import get_logger
-from .browser import BrowserConfig, BrowserManager, PageNavigator
-from .consent_handler import MLSConsentHandler
 
 logger = get_logger()
 
@@ -25,32 +28,49 @@ class QoPScraperError(Exception):
     pass
 
 
-# Qualification status substrings that appear inline with team names on the page
+# Age group → modular11 UID_age value
+AGE_GROUP_IDS: dict[str, str] = {
+    "U13": "21",
+    "U14": "22",
+    "U15": "33",
+    "U16": "14",
+    "U17": "15",
+    "U19": "26",
+}
+
 _QUALIFICATION_PATTERNS = re.compile(
     r"(Championship Qualification|Premier Qualification|Qualification|Qualified)",
     re.IGNORECASE,
 )
 
+_AGE_PREFIX = re.compile(r"^\s*U\d+\s+", re.IGNORECASE)
+
+# The standings page sometimes lists a "<Region> (Pro Player Pathway) Division"
+# alongside the plain "<Region> Division" heading. The QoP cronjob targets the
+# plain geographic Homegrown divisions, so we skip Pro Player Pathway rows by
+# default unless explicitly requested.
+_PRO_PLAYER_PATHWAY = "(pro player pathway)"
+
 
 def strip_qualification_text(raw: str) -> str:
-    """
-    Remove qualification status text from a raw team name string.
-
-    MLS Next standings pages render qualification labels (e.g. "Championship
-    Qualification", "Premier Qualification") as inline text adjacent to the
-    team name.  This function strips those substrings so only the club name
-    remains.
-
-    Args:
-        raw: Raw text extracted from the standings table team cell.
-
-    Returns:
-        Cleaned team name with leading/trailing whitespace removed.
-    """
+    """Remove qualification status text from a raw team name string."""
     cleaned = _QUALIFICATION_PATTERNS.sub("", raw)
-    # Collapse multiple internal spaces that may be left behind
     cleaned = re.sub(r"\s{2,}", " ", cleaned)
     return cleaned.strip()
+
+
+def _normalize_division_heading(title: str) -> str:
+    """
+    Reduce a ``data-title`` like "U15 Northeast Division" to "northeast".
+
+    Keeps "(pro player pathway)" as a suffix so callers can distinguish
+    geographic divisions from Pathway brackets.
+    """
+    t = title.strip().lower()
+    t = _AGE_PREFIX.sub("", t)
+    if t.endswith(" division"):
+        t = t[: -len(" division")]
+    return t.strip()
 
 
 class MLSQoPScraper:
@@ -63,139 +83,65 @@ class MLSQoPScraper:
         snapshot = await scraper.scrape()
     """
 
-    # URL template: age_group "U14" → "u14"
-    MLS_STANDINGS_URL_TEMPLATE = (
-        "https://www.mlssoccer.com/mlsnext/standings/{age_slug}/"
-    )
+    ENDPOINT_URL = "https://www.modular11.com/public_schedule/league/get_teams"
 
-    # Retry configuration (mirrors MLSScraper)
+    EVENT_ID = "12"  # MLS NEXT
+    LIST_TYPE = "53"  # QoP standings listing
+
+    REQUEST_TIMEOUT = 30.0
     MAX_RETRIES = 3
     RETRY_DELAY_BASE = 1.0
     RETRY_BACKOFF_MULTIPLIER = 2.0
-
-    # Selector timeout (ms)
-    DEFAULT_TIMEOUT = 10_000
 
     def __init__(
         self,
         age_group: str,
         division: str,
-        headless: bool = True,
+        headless: bool = True,  # noqa: ARG002 — kept for backwards compat with CLI
     ) -> None:
-        """
-        Initialize the QoP scraper.
-
-        Args:
-            age_group: Age group to scrape, e.g. "U14".
-            division:  Division label to select, e.g. "Northeast".
-                       Matched case-insensitively against options shown on the page.
-            headless:  Whether to run the browser in headless mode.
-        """
         self.age_group = age_group
         self.division = division
-        self.headless = headless
-        self.browser_manager: Optional[BrowserManager] = None
 
-        age_slug = age_group.lower()
-        self.standings_url = self.MLS_STANDINGS_URL_TEMPLATE.format(age_slug=age_slug)
+        if age_group not in AGE_GROUP_IDS:
+            raise QoPScraperError(
+                f"Unknown age group: {age_group!r}. Known: {sorted(AGE_GROUP_IDS)}"
+            )
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+        self.age_id = AGE_GROUP_IDS[age_group]
+        self._division_target = _normalize_division_heading(division)
 
     async def scrape(self) -> QoPSnapshot:
-        """
-        Navigate to the standings page, select the division filter, and extract
-        all team rankings.
-
-        Returns:
-            QoPSnapshot populated with the current standings data.
-
-        Raises:
-            QoPScraperError: If the scrape fails after all retries.
-        """
+        """Fetch and parse standings for the configured age group and division."""
         logger.info(
             "Starting QoP standings scrape",
             extra={
                 "age_group": self.age_group,
                 "division": self.division,
-                "url": self.standings_url,
+                "age_id": self.age_id,
             },
         )
 
-        last_exc: Optional[Exception] = None
+        html = await self._fetch_html()
+        rankings = self._parse_rankings(html)
 
-        for attempt in range(self.MAX_RETRIES):
-            try:
-                snapshot = await self._scrape_attempt()
-                logger.info(
-                    "QoP standings scrape completed",
-                    extra={
-                        "age_group": self.age_group,
-                        "division": self.division,
-                        "rankings_count": len(snapshot.rankings),
-                        "attempt": attempt + 1,
-                    },
-                )
-                return snapshot
-
-            except QoPScraperError:
-                # Non-retryable logical errors (e.g. division not found) — re-raise immediately
-                raise
-
-            except Exception as exc:
-                last_exc = exc
-                logger.warning(
-                    "QoP scrape attempt failed",
-                    extra={
-                        "attempt": attempt + 1,
-                        "max_retries": self.MAX_RETRIES,
-                        "error": str(exc),
-                        "error_type": type(exc).__name__,
-                    },
-                )
-
-                if attempt < self.MAX_RETRIES - 1:
-                    delay = self._retry_delay(attempt)
-                    logger.info(
-                        "Retrying QoP scrape",
-                        extra={"delay_seconds": delay, "next_attempt": attempt + 2},
-                    )
-                    await asyncio.sleep(delay)
-
-            finally:
-                # Clean up browser between retries
-                if self.browser_manager:
-                    await self.browser_manager.cleanup()
-                    self.browser_manager = None
-
-        raise QoPScraperError(
-            f"QoP scrape failed after {self.MAX_RETRIES} attempts: {last_exc}"
-        ) from last_exc
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    async def _scrape_attempt(self) -> QoPSnapshot:
-        """Execute a single scrape attempt (browser init → navigate → extract)."""
-        # Initialise browser
-        browser_config = BrowserConfig(
-            headless=self.headless,
-            timeout=30_000,
-            viewport_width=1280,
-            viewport_height=720,
-        )
-        self.browser_manager = BrowserManager(browser_config)
-        await self.browser_manager.initialize()
-
-        async with self.browser_manager.get_page() as page:
-            await self._navigate(page)
-            await self._select_division(page)
-            rankings = await self._extract_rankings(page)
+        if not rankings:
+            raise QoPScraperError(
+                f"No QoP rankings found for {self.age_group} {self.division}. "
+                "The division may not expose QoP metrics (some age groups only "
+                "publish standard league standings) or the page structure changed."
+            )
 
         today = date.today()
         week_of = today - timedelta(days=today.weekday())
+
+        logger.info(
+            "QoP standings scrape completed",
+            extra={
+                "age_group": self.age_group,
+                "division": self.division,
+                "rankings_count": len(rankings),
+            },
+        )
 
         return QoPSnapshot(
             week_of=week_of,
@@ -205,228 +151,152 @@ class MLSQoPScraper:
             rankings=rankings,
         )
 
-    async def _navigate(self, page: Any) -> None:
-        """Navigate to the standings URL and handle consent banners."""
-        logger.info("Navigating to standings page", extra={"url": self.standings_url})
+    async def _fetch_html(self) -> str:
+        """GET the modular11 get_teams endpoint with retries."""
+        params = {
+            "tournament_type": "league",
+            "UID_age": self.age_id,
+            "UID_gender": "0",
+            "UID_event": self.EVENT_ID,
+            "list_type": self.LIST_TYPE,
+        }
+        headers = {
+            "User-Agent": "Mozilla/5.0 (compatible; mls-match-scraper/QoP)",
+            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "text/html,*/*",
+        }
 
-        navigator = PageNavigator(page, max_retries=self.MAX_RETRIES)
-        success = await navigator.navigate_to(self.standings_url, wait_until="load")
-        if not success:
-            raise QoPScraperError(
-                f"Failed to navigate to standings page: {self.standings_url}"
-            )
-
-        logger.info("Navigation successful — handling consent banner")
-        consent_handler = MLSConsentHandler(page)
-        consent_handled = await consent_handler.handle_consent_banner()
-        if not consent_handled:
-            logger.warning("Consent handling failed; continuing anyway")
-
-        page_ready = await consent_handler.wait_for_page_ready()
-        if not page_ready:
-            logger.warning("Page readiness check failed; continuing anyway")
-
-    async def _select_division(self, page: Any) -> None:
-        """
-        Find the division filter control on the page and select the target division.
-
-        The MLS Next standings page may expose the division filter as:
-          - A native <select> element
-          - A button-based dropdown (div/ul with clickable items)
-
-        We try the native select first, then fall back to button-based interaction.
-        """
-        target = self.division.lower()
-        logger.info("Selecting division filter", extra={"division": self.division})
-
-        # --- Strategy 1: native <select> element ---
-        selected = await self._try_select_element(page, target)
-        if selected:
-            logger.info("Division selected via <select> element")
-            await page.wait_for_timeout(1500)
-            return
-
-        # --- Strategy 2: clickable filter buttons / links ---
-        selected = await self._try_button_filter(page, target)
-        if selected:
-            logger.info("Division selected via button/link filter")
-            await page.wait_for_timeout(1500)
-            return
+        last_exc: Exception | None = None
+        async with httpx.AsyncClient(timeout=self.REQUEST_TIMEOUT) as client:
+            for attempt in range(self.MAX_RETRIES):
+                try:
+                    resp = await client.get(
+                        self.ENDPOINT_URL, params=params, headers=headers
+                    )
+                    resp.raise_for_status()
+                    return resp.text
+                except (httpx.HTTPError, httpx.RequestError) as exc:
+                    last_exc = exc
+                    logger.warning(
+                        "QoP endpoint fetch failed",
+                        extra={
+                            "attempt": attempt + 1,
+                            "max_retries": self.MAX_RETRIES,
+                            "error": str(exc),
+                            "error_type": type(exc).__name__,
+                        },
+                    )
+                    if attempt < self.MAX_RETRIES - 1:
+                        await asyncio.sleep(
+                            self.RETRY_DELAY_BASE
+                            * (self.RETRY_BACKOFF_MULTIPLIER**attempt)
+                        )
 
         raise QoPScraperError(
-            f"Division filter not found for '{self.division}'. "
-            "The page structure may have changed or the division name is incorrect."
-        )
+            f"QoP endpoint fetch failed after {self.MAX_RETRIES} attempts: {last_exc}"
+        ) from last_exc
 
-    async def _try_select_element(self, page: Any, target_lower: str) -> bool:
+    def _parse_rankings(self, html: str) -> list[QoPRanking]:
         """
-        Attempt to select the division using a native <select> dropdown.
+        Parse the modular11 HTML fragment and extract rankings for the target division.
 
-        Returns True if the division was successfully selected.
+        The endpoint returns rows for every division in the age group. Division
+        boundaries are marked by ``<p data-title="... Division">`` headings; team
+        rows follow each heading until the next one. We walk the document in
+        order, track the current heading, and collect rows only while the heading
+        matches the target division.
         """
-        # Common selector patterns for MLS Next filter dropdowns
-        select_selectors = [
-            "select[name*='division']",
-            "select[id*='division']",
-            "select[class*='division']",
-            "select[name*='group']",
-            "select[id*='group']",
-            "select",  # broad fallback — iterate all selects
-        ]
-
-        for sel in select_selectors:
-            try:
-                select_elements = await page.query_selector_all(sel)
-                for select_el in select_elements:
-                    options = await select_el.query_selector_all("option")
-                    for option in options:
-                        text = await option.text_content() or ""
-                        if target_lower in text.lower():
-                            value = await option.get_attribute("value") or text.strip()
-                            await select_el.select_option(value=value)
-                            return True
-            except Exception as exc:
-                logger.debug(
-                    "select_element attempt failed",
-                    extra={"selector": sel, "error": str(exc)},
-                )
-
-        return False
-
-    async def _try_button_filter(self, page: Any, target_lower: str) -> bool:
-        """
-        Attempt to select the division by clicking a button or link that contains
-        the division name.
-
-        Returns True if the division was successfully selected.
-        """
-        # Selectors for MLS Next filter pill/button patterns
-        button_selectors = [
-            f"button:has-text('{self.division}')",
-            f"a:has-text('{self.division}')",
-            f"[data-value*='{self.division}']",
-            f"[data-filter*='{self.division}']",
-        ]
-
-        for sel in button_selectors:
-            try:
-                el = await page.query_selector(sel)
-                if el:
-                    await el.click()
-                    return True
-            except Exception:
-                pass
-
-        # Broader search: find any clickable element whose visible text contains
-        # the division name (case-insensitive)
-        try:
-            candidates = await page.query_selector_all(
-                "button, a, [role='option'], [role='button'], li"
-            )
-            for el in candidates:
-                text = await el.text_content() or ""
-                if target_lower in text.lower() and "division" in text.lower():
-                    await el.click()
-                    return True
-        except Exception as exc:
-            logger.debug("Broad button filter search failed", extra={"error": str(exc)})
-
-        return False
-
-    async def _extract_rankings(self, page: Any) -> list[QoPRanking]:
-        """
-        Wait for the standings table and extract all rows.
-
-        Returns:
-            List of QoPRanking objects ordered by rank.
-        """
-        logger.info("Waiting for standings table")
-
-        # Try multiple table selectors
-        table_selectors = [
-            "table tbody tr",
-            "tbody tr",
-            "[class*='standings'] tr",
-            "[class*='table'] tr",
-            "tr",
-        ]
-
-        rows = []
-        for sel in table_selectors:
-            try:
-                await page.wait_for_selector(sel, timeout=self.DEFAULT_TIMEOUT)
-                rows = await page.query_selector_all(sel)
-                if rows:
-                    logger.info(
-                        "Found standings rows",
-                        extra={"selector": sel, "row_count": len(rows)},
-                    )
-                    break
-            except Exception:
-                continue
-
-        if not rows:
-            raise QoPScraperError(
-                "Could not locate standings table rows on the page. "
-                "The page structure may have changed."
-            )
+        soup = BeautifulSoup(html, "html.parser")
+        target = self._division_target
 
         rankings: list[QoPRanking] = []
-        skipped = 0
+        current_match = False
+        found_target = False
+        skipped_rows = 0
 
-        for row in rows:
-            cells = await row.query_selector_all("td")
-            if len(cells) < 6:
-                # Skip header rows or malformed rows
-                skipped += 1
+        # Walk relevant elements in document order
+        for el in soup.find_all(
+            lambda t: (
+                t.name == "p"
+                and t.has_attr("data-title")
+                and "division" in (t.get("data-title") or "").lower()
+            )
+            or (
+                t.name == "div"
+                and "form_row" in (t.get("class") or [])
+                and "main_row" in (t.get("class") or [])
+            )
+        ):
+            if el.name == "p":
+                heading = _normalize_division_heading(el.get("data-title") or "")
+                # Skip Pro Player Pathway brackets unless explicitly requested
+                if _PRO_PLAYER_PATHWAY in heading and _PRO_PLAYER_PATHWAY not in target:
+                    current_match = False
+                    continue
+                current_match = heading == target
+                if current_match:
+                    found_target = True
                 continue
 
-            try:
-                rank_text = (await cells[0].text_content() or "").strip()
-                team_raw = (await cells[1].text_content() or "").strip()
-                mp_text = (await cells[2].text_content() or "").strip()
-                att_text = (await cells[3].text_content() or "").strip()
-                def_text = (await cells[4].text_content() or "").strip()
-                qop_text = (await cells[5].text_content() or "").strip()
+            if current_match:
+                ranking = self._parse_row(el)
+                if ranking is None:
+                    skipped_rows += 1
+                else:
+                    rankings.append(ranking)
 
-                rank = int(rank_text)
-                team_name = strip_qualification_text(team_raw)
-                matches_played = int(mp_text)
-                att_score = float(att_text)
-                def_score = float(def_text)
-                qop_score = float(qop_text)
-
-                rankings.append(
-                    QoPRanking(
-                        rank=rank,
-                        team_name=team_name,
-                        matches_played=matches_played,
-                        att_score=att_score,
-                        def_score=def_score,
-                        qop_score=qop_score,
-                    )
-                )
-
-            except (ValueError, IndexError) as exc:
-                skipped += 1
-                logger.debug(
-                    "Skipping unparseable standings row",
-                    extra={"error": str(exc)},
-                )
-
-        logger.info(
-            "Standings extraction complete",
-            extra={"parsed_rows": len(rankings), "skipped_rows": skipped},
-        )
-
-        if not rankings:
+        if not found_target:
             raise QoPScraperError(
-                "No rankings could be extracted from the standings table. "
-                "Check that the correct division is selected and the page rendered."
+                f"Division heading for {self.division!r} not found in "
+                f"{self.age_group} standings response. The division may not "
+                "exist for this age group."
             )
 
-        return rankings
+        logger.info(
+            "QoP row parsing complete",
+            extra={"parsed": len(rankings), "skipped": skipped_rows},
+        )
 
-    def _retry_delay(self, attempt: int) -> float:
-        """Calculate exponential backoff delay for a given attempt (0-based)."""
-        return self.RETRY_DELAY_BASE * (self.RETRY_BACKOFF_MULTIPLIER**attempt)
+        return sorted(rankings, key=lambda r: r.rank)
+
+    @staticmethod
+    def _parse_row(row: Tag) -> QoPRanking | None:
+        """
+        Extract a single QoPRanking from a ``.form_row.main_row`` element.
+
+        QoP rows have exactly 4 stat cells (``.col-sm-3.hidden-xs``) containing
+        matches played, attack score, defense score, and QoP score. Age groups
+        that publish traditional standings (W/L/T/GF/GA/etc.) use 9x
+        ``.col-sm-1.hidden-xs`` cells instead — those rows are skipped.
+        """
+        try:
+            rank_el = row.select_one(".container-rank")
+            team_el = row.select_one(".container-team-info p[data-title]")
+            stat_cells = row.select(".subrow.pad-left .col-sm-3.hidden-xs")
+
+            if rank_el is None or team_el is None or len(stat_cells) != 4:
+                return None
+
+            rank = int(rank_el.get_text(strip=True))
+            team_name = strip_qualification_text(
+                team_el.get("data-title") or team_el.get_text(strip=True)
+            )
+            matches_played = int(stat_cells[0].get_text(strip=True))
+            att_score = float(stat_cells[1].get_text(strip=True))
+            def_score = float(stat_cells[2].get_text(strip=True))
+            qop_score = float(stat_cells[3].get_text(strip=True))
+
+            return QoPRanking(
+                rank=rank,
+                team_name=team_name,
+                matches_played=matches_played,
+                att_score=att_score,
+                def_score=def_score,
+                qop_score=qop_score,
+            )
+        except (ValueError, AttributeError) as exc:
+            logger.debug(
+                "Skipping unparseable QoP row",
+                extra={"error": str(exc)},
+            )
+            return None

--- a/tests/unit/test_qop_scraper.py
+++ b/tests/unit/test_qop_scraper.py
@@ -1,44 +1,50 @@
-"""Unit tests for MLSQoPScraper and related helpers."""
+"""Unit tests for MLSQoPScraper (httpx + BeautifulSoup implementation)."""
+
+from __future__ import annotations
 
 from datetime import date, timedelta
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
-from src.models.qop_ranking import QoPRanking, QoPSnapshot
 from src.scraper.qop_scraper import (
+    AGE_GROUP_IDS,
     MLSQoPScraper,
     QoPScraperError,
+    _normalize_division_heading,
     strip_qualification_text,
 )
 
 # ---------------------------------------------------------------------------
-# Pure-function tests — no mocking needed
+# strip_qualification_text
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestStripQualificationText:
-    """Tests for the strip_qualification_text() helper."""
-
     def test_plain_name_unchanged(self):
         assert strip_qualification_text("New York City FC") == "New York City FC"
 
     def test_championship_qualification_removed(self):
-        raw = "New York City FCChampionship Qualification"
-        assert strip_qualification_text(raw) == "New York City FC"
+        assert (
+            strip_qualification_text("New York City FCChampionship Qualification")
+            == "New York City FC"
+        )
 
     def test_premier_qualification_removed(self):
-        raw = "FC Dallas Premier Qualification"
-        assert strip_qualification_text(raw) == "FC Dallas"
+        assert (
+            strip_qualification_text("FC Dallas Premier Qualification") == "FC Dallas"
+        )
 
     def test_bare_qualification_removed(self):
-        raw = "LA Galaxy Qualification"
-        assert strip_qualification_text(raw) == "LA Galaxy"
+        assert strip_qualification_text("LA Galaxy Qualification") == "LA Galaxy"
 
     def test_case_insensitive_removal(self):
-        raw = "Chicago Fire FC championship qualification"
-        assert strip_qualification_text(raw) == "Chicago Fire FC"
+        assert (
+            strip_qualification_text("Chicago Fire FC championship qualification")
+            == "Chicago Fire FC"
+        )
 
     def test_leading_trailing_whitespace_stripped(self):
         assert strip_qualification_text("  Real Salt Lake  ") == "Real Salt Lake"
@@ -47,674 +53,322 @@ class TestStripQualificationText:
         assert strip_qualification_text("") == ""
 
     def test_multiple_spaces_collapsed(self):
-        # After stripping "Qualification" internal spaces should be collapsed
-        raw = "Portland  Timbers  Qualification"
-        result = strip_qualification_text(raw)
+        result = strip_qualification_text("Portland  Timbers  Qualification")
         assert "  " not in result
-        assert "Portland" in result
-        assert "Timbers" in result
+        assert result == "Portland Timbers"
 
 
 # ---------------------------------------------------------------------------
-# week_of logic
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestWeekOf:
-    """Verify the week_of calculation always lands on a Monday."""
-
-    def test_week_of_is_monday(self):
-        """Regardless of when tests run, week_of must be the Monday of current week."""
-        today = date.today()
-        expected_monday = today - timedelta(days=today.weekday())
-        # Simulate what the scraper does
-        computed = today - timedelta(days=today.weekday())
-        assert computed == expected_monday
-        assert computed.weekday() == 0  # 0 == Monday
-
-    def test_week_of_is_not_in_future(self):
-        today = date.today()
-        week_of = today - timedelta(days=today.weekday())
-        assert week_of <= today
-
-
-# ---------------------------------------------------------------------------
-# QoPScraperError
+# _normalize_division_heading
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestQoPScraperError:
-    def test_is_exception(self):
-        err = QoPScraperError("boom")
-        assert isinstance(err, Exception)
-        assert str(err) == "boom"
+class TestNormalizeDivisionHeading:
+    def test_strips_age_prefix(self):
+        assert _normalize_division_heading("U15 Northeast Division") == "northeast"
 
-    def test_chaining(self):
-        original = ValueError("root cause")
-        try:
-            raise QoPScraperError("wrapper") from original
-        except QoPScraperError as exc:
-            assert exc.__cause__ is original
+    def test_strips_age_prefix_lowercase(self):
+        assert _normalize_division_heading("u14 Northeast Division") == "northeast"
+
+    def test_no_age_prefix(self):
+        assert _normalize_division_heading("Northeast Division") == "northeast"
+
+    def test_preserves_pathway_suffix(self):
+        assert (
+            _normalize_division_heading("U16 Northeast (Pro Player Pathway) Division")
+            == "northeast (pro player pathway)"
+        )
+
+    def test_whitespace_stripped(self):
+        assert (
+            _normalize_division_heading("  Mid-Atlantic Division  ") == "mid-atlantic"
+        )
 
 
 # ---------------------------------------------------------------------------
-# MLSQoPScraper initialisation
+# Init validation
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestMLSQoPScraperInit:
-    def test_url_built_correctly_for_u14(self):
+    def test_accepts_known_age_group(self):
         scraper = MLSQoPScraper(age_group="U14", division="Northeast")
-        assert "u14" in scraper.standings_url
-        assert scraper.standings_url.startswith("https://")
-
-    def test_url_built_correctly_for_u16(self):
-        scraper = MLSQoPScraper(age_group="U16", division="Southeast")
-        assert "u16" in scraper.standings_url
-
-    def test_attributes_stored(self):
-        scraper = MLSQoPScraper(age_group="U14", division="Northeast", headless=False)
-        assert scraper.age_group == "U14"
+        assert scraper.age_id == AGE_GROUP_IDS["U14"]
         assert scraper.division == "Northeast"
-        assert scraper.headless is False
 
-    def test_retry_constants_exist(self):
-        assert MLSQoPScraper.MAX_RETRIES == 3
-        assert MLSQoPScraper.RETRY_DELAY_BASE > 0
+    def test_rejects_unknown_age_group(self):
+        with pytest.raises(QoPScraperError, match="Unknown age group"):
+            MLSQoPScraper(age_group="U99", division="Northeast")
 
+    def test_division_target_is_normalized(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        assert scraper._division_target == "northeast"
 
-# ---------------------------------------------------------------------------
-# Helpers for mocking the Playwright page
-# ---------------------------------------------------------------------------
+    def test_all_age_groups_have_mapping(self):
+        for age in ["U13", "U14", "U15", "U16", "U17", "U19"]:
+            scraper = MLSQoPScraper(age_group=age, division="Northeast")
+            assert scraper.age_id == AGE_GROUP_IDS[age]
 
-
-def _make_cell(text: str) -> AsyncMock:
-    """Create a mock <td> element that returns *text* from text_content()."""
-    cell = AsyncMock()
-    cell.text_content = AsyncMock(return_value=text)
-    return cell
-
-
-def _make_row(rank, team, mp, att, def_, qop) -> AsyncMock:
-    """Create a mock <tr> element with 6 <td> cells."""
-    row = AsyncMock()
-    cells = [
-        _make_cell(str(rank)),
-        _make_cell(team),
-        _make_cell(str(mp)),
-        _make_cell(str(att)),
-        _make_cell(str(def_)),
-        _make_cell(str(qop)),
-    ]
-    row.query_selector_all = AsyncMock(return_value=cells)
-    return row
-
-
-def _make_short_row() -> AsyncMock:
-    """Create a row with too few cells (header-like)."""
-    row = AsyncMock()
-    row.query_selector_all = AsyncMock(return_value=[_make_cell("Rank")])
-    return row
+    def test_accepts_headless_kwarg_for_backwards_compat(self):
+        # CLI passes headless=True/False; scraper should accept without error.
+        MLSQoPScraper(age_group="U14", division="Northeast", headless=False)
 
 
 # ---------------------------------------------------------------------------
-# _extract_rankings
+# Parser (fixture-based HTML)
 # ---------------------------------------------------------------------------
+
+
+def _qop_row_html(
+    rank: int, team: str, mp: int, att: float, defn: float, qop: float
+) -> str:
+    return f"""
+    <div class="form_row row main_row" js-group="41" row="division{rank}">
+      <div class="col-xs-9 col-sm-6">
+        <div class="row subrow pad-right">
+          <div class="col-xs-1 col-sm-2 container-rank pad-0 text-center">{rank}</div>
+          <div class="col-xs-9 col-sm-8">
+            <div class="container-team-info">
+              <p data-title="{team}">{team}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-3 col-sm-6">
+        <div class="row subrow pad-left">
+          <div class="col-sm-3 pad-0 gap-right-mobile-lg hidden-xs">{mp}</div>
+          <div class="col-sm-3 pad-0 gap-right-mobile-lg hidden-xs">{att}</div>
+          <div class="col-sm-3 pad-0 gap-right-mobile-sm hidden-xs">{defn}</div>
+          <div class="col-sm-3 pad-0 gap-right-mobile-sm hidden-xs">{qop}</div>
+        </div>
+      </div>
+    </div>
+    """
+
+
+def _traditional_row_html(rank: int, team: str) -> str:
+    """A non-QoP standings row (9 col-sm-1 cells). Should be skipped."""
+    cells = "".join(
+        f'<div class="col-sm-1 pad-0 hidden-xs">{i}</div>' for i in range(9)
+    )
+    return f"""
+    <div class="form_row row main_row" js-group="41" row="division{rank}">
+      <div class="col-xs-9 col-sm-6">
+        <div class="row subrow pad-right">
+          <div class="col-xs-1 col-sm-2 container-rank pad-0 text-center">{rank}</div>
+          <div class="container-team-info"><p data-title="{team}">{team}</p></div>
+        </div>
+      </div>
+      <div class="col-xs-3 col-sm-6">
+        <div class="row subrow pad-left">{cells}</div>
+      </div>
+    </div>
+    """
+
+
+def _heading_html(title: str) -> str:
+    return f'<p data-title="{title}">{title}</p>'
 
 
 @pytest.mark.unit
-class TestExtractRankings:
-    """Tests for MLSQoPScraper._extract_rankings() in isolation."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_extracts_valid_rows(self, scraper):
-        page = AsyncMock()
-
-        rows = [
-            _make_short_row(),  # header — should be skipped
-            _make_row(1, "New York City FC", 16, 89.6, 83.1, 87.6),
-            _make_row(2, "FC Dallas", 15, 78.2, 75.0, 77.1),
-        ]
-
-        page.wait_for_selector = AsyncMock(return_value=None)
-        page.query_selector_all = AsyncMock(return_value=rows)
-
-        rankings = await scraper._extract_rankings(page)
-
+class TestParseRankings:
+    def test_extracts_target_division_rows(self):
+        html = (
+            _heading_html("Mid-Atlantic Division")
+            + _qop_row_html(1, "Other Team", 10, 70.0, 70.0, 70.0)
+            + _heading_html("Northeast Division")
+            + _qop_row_html(1, "New York City FC", 16, 89.6, 83.1, 87.6)
+            + _qop_row_html(2, "Red Bulls", 15, 87.3, 78.8, 84.8)
+        )
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        rankings = scraper._parse_rankings(html)
         assert len(rankings) == 2
         assert rankings[0].rank == 1
         assert rankings[0].team_name == "New York City FC"
-        assert rankings[0].qop_score == pytest.approx(87.6)
-        assert rankings[1].rank == 2
+        assert rankings[0].qop_score == 87.6
+        assert rankings[1].team_name == "Red Bulls"
 
-    @pytest.mark.asyncio
-    async def test_strips_qualification_text_from_team_name(self, scraper):
-        page = AsyncMock()
-
-        rows = [
-            _make_row(
-                1,
-                "New York City FCChampionship Qualification",
-                14,
-                90.0,
-                80.0,
-                85.0,
-            )
-        ]
-
-        page.wait_for_selector = AsyncMock(return_value=None)
-        page.query_selector_all = AsyncMock(return_value=rows)
-
-        rankings = await scraper._extract_rankings(page)
-
-        assert len(rankings) == 1
-        assert rankings[0].team_name == "New York City FC"
-
-    @pytest.mark.asyncio
-    async def test_raises_when_no_rows_found(self, scraper):
-        page = AsyncMock()
-        page.wait_for_selector = AsyncMock(side_effect=Exception("timeout"))
-        page.query_selector_all = AsyncMock(return_value=[])
-
-        with pytest.raises(QoPScraperError, match="standings table rows"):
-            await scraper._extract_rankings(page)
-
-    @pytest.mark.asyncio
-    async def test_raises_when_all_rows_unparseable(self, scraper):
-        page = AsyncMock()
-
-        bad_row = AsyncMock()
-        bad_row.query_selector_all = AsyncMock(
-            return_value=[
-                _make_cell("foo"),
-                _make_cell("bar"),
-                _make_cell("baz"),
-                _make_cell("qux"),
-                _make_cell("quux"),
-                _make_cell("corge"),
-            ]
+    def test_rankings_sorted_by_rank(self):
+        html = (
+            _heading_html("Northeast Division")
+            + _qop_row_html(3, "C", 10, 70.0, 70.0, 70.0)
+            + _qop_row_html(1, "A", 10, 90.0, 90.0, 90.0)
+            + _qop_row_html(2, "B", 10, 80.0, 80.0, 80.0)
         )
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        rankings = scraper._parse_rankings(html)
+        assert [r.rank for r in rankings] == [1, 2, 3]
+        assert [r.team_name for r in rankings] == ["A", "B", "C"]
 
-        page.wait_for_selector = AsyncMock(return_value=None)
-        page.query_selector_all = AsyncMock(return_value=[bad_row])
+    def test_matches_with_age_prefixed_heading(self):
+        html = _heading_html("U15 Northeast Division") + _qop_row_html(
+            1, "Team A", 10, 80.0, 80.0, 80.0
+        )
+        scraper = MLSQoPScraper(age_group="U15", division="Northeast")
+        rankings = scraper._parse_rankings(html)
+        assert len(rankings) == 1
+        assert rankings[0].team_name == "Team A"
 
-        with pytest.raises(QoPScraperError, match="No rankings could be extracted"):
-            await scraper._extract_rankings(page)
+    def test_skips_pro_player_pathway_when_geographic_requested(self):
+        html = (
+            _heading_html("U16 Northeast (Pro Player Pathway) Division")
+            + _qop_row_html(1, "Pathway Team", 10, 80.0, 80.0, 80.0)
+            + _heading_html("U16 Northeast Division")
+            + _qop_row_html(1, "Geographic Team", 10, 85.0, 85.0, 85.0)
+        )
+        scraper = MLSQoPScraper(age_group="U16", division="Northeast")
+        rankings = scraper._parse_rankings(html)
+        assert len(rankings) == 1
+        assert rankings[0].team_name == "Geographic Team"
+
+    def test_skips_traditional_standings_rows(self):
+        html = (
+            _heading_html("U15 Northeast Division")
+            + _traditional_row_html(1, "Team A")
+            + _traditional_row_html(2, "Team B")
+        )
+        scraper = MLSQoPScraper(age_group="U15", division="Northeast")
+        rankings = scraper._parse_rankings(html)
+        assert rankings == []
+
+    def test_raises_when_target_division_missing(self):
+        html = _heading_html("Mid-Atlantic Division") + _qop_row_html(
+            1, "X", 10, 70.0, 70.0, 70.0
+        )
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        with pytest.raises(QoPScraperError, match="not found"):
+            scraper._parse_rankings(html)
+
+    def test_qualification_text_stripped_from_team_name(self):
+        html = (
+            _heading_html("Northeast Division")
+            + """
+        <div class="form_row row main_row" js-group="41" row="division1">
+          <div class="col-xs-9 col-sm-6">
+            <div class="row subrow pad-right">
+              <div class="col-xs-1 col-sm-2 container-rank pad-0 text-center">1</div>
+              <div class="container-team-info">
+                <p data-title="Philadelphia Union">
+                  Philadelphia Union Championship Qualification
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="col-xs-3 col-sm-6">
+            <div class="row subrow pad-left">
+              <div class="col-sm-3 pad-0 hidden-xs">16</div>
+              <div class="col-sm-3 pad-0 hidden-xs">85.6</div>
+              <div class="col-sm-3 pad-0 hidden-xs">82.1</div>
+              <div class="col-sm-3 pad-0 hidden-xs">84.5</div>
+            </div>
+          </div>
+        </div>
+        """
+        )
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        rankings = scraper._parse_rankings(html)
+        assert rankings[0].team_name == "Philadelphia Union"
 
 
 # ---------------------------------------------------------------------------
-# Division filter not found
+# scrape() — end-to-end with mocked HTTP
 # ---------------------------------------------------------------------------
+
+
+def _make_successful_html() -> str:
+    return (
+        _heading_html("Northeast Division")
+        + _qop_row_html(1, "New York City FC", 16, 89.6, 83.1, 87.6)
+        + _qop_row_html(2, "Red Bulls", 15, 87.3, 78.8, 84.8)
+    )
 
 
 @pytest.mark.unit
-class TestSelectDivision:
-    """Tests for MLSQoPScraper._select_division() edge cases."""
+@pytest.mark.asyncio
+class TestScrape:
+    async def test_scrape_returns_snapshot_with_rankings(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
 
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_raises_when_division_not_found(self, scraper):
-        """_select_division must raise QoPScraperError if no filter matches."""
-        page = AsyncMock()
-        # All strategies return nothing useful
-        page.query_selector_all = AsyncMock(return_value=[])
-        page.query_selector = AsyncMock(return_value=None)
-        page.wait_for_timeout = AsyncMock(return_value=None)
-
-        with pytest.raises(QoPScraperError, match="Division filter not found"):
-            await scraper._select_division(page)
-
-    @pytest.mark.asyncio
-    async def test_selects_via_native_select_element(self, scraper):
-        """_try_select_element should select the matching option."""
-        page = AsyncMock()
-
-        option = AsyncMock()
-        option.text_content = AsyncMock(return_value="Northeast Division")
-        option.get_attribute = AsyncMock(return_value="northeast-division")
-
-        select_el = AsyncMock()
-        select_el.query_selector_all = AsyncMock(return_value=[option])
-        select_el.select_option = AsyncMock(return_value=None)
-
-        # Return select_el for the first broad "select" query
-        page.query_selector_all = AsyncMock(return_value=[select_el])
-        page.query_selector = AsyncMock(return_value=None)
-        page.wait_for_timeout = AsyncMock(return_value=None)
-
-        # Should not raise
-        await scraper._select_division(page)
-
-        select_el.select_option.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# Full scrape() — integration-level mock
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestMLSQoPScraperScrape:
-    """Tests for the top-level scrape() method using heavily mocked internals."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_scrape_returns_snapshot(self, scraper):
-        """A successful scrape should return a valid QoPSnapshot."""
-        fake_rankings = [
-            QoPRanking(
-                rank=1,
-                team_name="Club A",
-                matches_played=10,
-                att_score=85.0,
-                def_score=80.0,
-                qop_score=83.0,
-            )
-        ]
-
-        with (
-            patch.object(
-                scraper, "_scrape_attempt", new_callable=AsyncMock
-            ) as mock_attempt,
-        ):
-            today = date.today()
-            week_of = today - timedelta(days=today.weekday())
-            from datetime import datetime, timezone
-
-            mock_attempt.return_value = QoPSnapshot(
-                week_of=week_of,
-                division="Northeast",
-                age_group="U14",
-                scraped_at=datetime.now(tz=timezone.utc),
-                rankings=fake_rankings,
-            )
-
+        with patch.object(scraper, "_fetch_html", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = _make_successful_html()
             snapshot = await scraper.scrape()
 
-        assert isinstance(snapshot, QoPSnapshot)
         assert snapshot.age_group == "U14"
         assert snapshot.division == "Northeast"
-        assert len(snapshot.rankings) == 1
-        assert snapshot.rankings[0].team_name == "Club A"
-        assert snapshot.week_of.weekday() == 0  # Monday
+        assert len(snapshot.rankings) == 2
+        assert snapshot.rankings[0].team_name == "New York City FC"
 
-    @pytest.mark.asyncio
-    async def test_scrape_reraises_qop_scraper_error_immediately(self, scraper):
-        """QoPScraperError (logical errors) should not be retried."""
-        call_count = 0
+    async def test_scrape_week_of_is_monday(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        with patch.object(scraper, "_fetch_html", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = _make_successful_html()
+            snapshot = await scraper.scrape()
 
-        async def failing_attempt():
-            nonlocal call_count
-            call_count += 1
-            raise QoPScraperError("Division not found")
+        today = date.today()
+        expected_monday = today - timedelta(days=today.weekday())
+        assert snapshot.week_of == expected_monday
+        assert snapshot.week_of.weekday() == 0
 
-        with patch.object(scraper, "_scrape_attempt", side_effect=failing_attempt):
-            with pytest.raises(QoPScraperError, match="Division not found"):
+    async def test_scrape_raises_when_rankings_empty(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        html = _heading_html("Northeast Division")  # heading but no rows
+        with patch.object(scraper, "_fetch_html", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = html
+            with pytest.raises(QoPScraperError, match="No QoP rankings found"):
                 await scraper.scrape()
 
-        # Should fail on first attempt without retrying
-        assert call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_scrape_retries_on_generic_exception(self, scraper):
-        """Generic exceptions should trigger retries up to MAX_RETRIES."""
-        call_count = 0
-
-        async def always_fails():
-            nonlocal call_count
-            call_count += 1
-            raise RuntimeError("network error")
-
-        with (
-            patch.object(scraper, "_scrape_attempt", side_effect=always_fails),
-            patch("asyncio.sleep", new_callable=AsyncMock),
-        ):
-            with pytest.raises(QoPScraperError):
-                await scraper.scrape()
-
-    @pytest.mark.asyncio
-    async def test_browser_manager_cleaned_up_after_failure(self, scraper):
-        """browser_manager.cleanup() must be called even when _scrape_attempt raises."""
-        mock_bm = AsyncMock()
-        mock_bm.cleanup = AsyncMock()
-
-        async def failing_attempt():
-            scraper.browser_manager = mock_bm
-            raise RuntimeError("boom")
-
-        with (
-            patch.object(scraper, "_scrape_attempt", side_effect=failing_attempt),
-            patch("asyncio.sleep", new_callable=AsyncMock),
-        ):
-            with pytest.raises(QoPScraperError):
-                await scraper.scrape()
-
-        mock_bm.cleanup.assert_called()
-
-
-# ---------------------------------------------------------------------------
-# _scrape_attempt  (mocking BrowserManager)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestScrapeAttempt:
-    """Tests for MLSQoPScraper._scrape_attempt() with BrowserManager mocked."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_scrape_attempt_returns_snapshot(self, scraper):
-        """_scrape_attempt should initialise browser, call sub-methods, build QoPSnapshot."""
-        real_ranking = __import__(
-            "src.models.qop_ranking", fromlist=["QoPRanking"]
-        ).QoPRanking(
-            rank=1,
-            team_name="FC Test",
-            matches_played=12,
-            att_score=80.0,
-            def_score=75.0,
-            qop_score=78.0,
+    async def test_scrape_reraises_division_not_found(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
+        html = _heading_html("Mid-Atlantic Division") + _qop_row_html(
+            1, "X", 10, 70.0, 70.0, 70.0
         )
-
-        mock_page = AsyncMock()
-        mock_page.wait_for_timeout = AsyncMock()
-
-        # Build a mock BrowserManager whose get_page() context manager yields mock_page
-        from contextlib import asynccontextmanager
-
-        @asynccontextmanager
-        async def _fake_get_page():
-            yield mock_page
-
-        mock_bm = AsyncMock()
-        mock_bm.initialize = AsyncMock()
-        mock_bm.get_page = _fake_get_page
-        mock_bm.cleanup = AsyncMock()
-
-        with (
-            patch("src.scraper.qop_scraper.BrowserManager", return_value=mock_bm),
-            patch("src.scraper.qop_scraper.BrowserConfig"),
-            patch.object(scraper, "_navigate", new_callable=AsyncMock),
-            patch.object(scraper, "_select_division", new_callable=AsyncMock),
-            patch.object(
-                scraper,
-                "_extract_rankings",
-                new_callable=AsyncMock,
-                return_value=[real_ranking],
-            ),
-        ):
-            snapshot = await scraper._scrape_attempt()
-
-        assert isinstance(snapshot, QoPSnapshot)
-        assert snapshot.age_group == "U14"
-        assert snapshot.division == "Northeast"
-        assert snapshot.week_of.weekday() == 0  # Monday
-        assert len(snapshot.rankings) == 1
-        mock_bm.initialize.assert_called_once()
+        with patch.object(scraper, "_fetch_html", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = html
+            with pytest.raises(QoPScraperError, match="not found"):
+                await scraper.scrape()
 
 
 # ---------------------------------------------------------------------------
-# _navigate
+# _fetch_html — retry + error paths
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestNavigate:
-    """Tests for MLSQoPScraper._navigate()."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_navigate_success(self, scraper):
-        """Successful navigation calls consent handler and page ready check."""
-        page = AsyncMock()
-
-        mock_navigator = AsyncMock()
-        mock_navigator.navigate_to = AsyncMock(return_value=True)
-
-        mock_consent = AsyncMock()
-        mock_consent.handle_consent_banner = AsyncMock(return_value=True)
-        mock_consent.wait_for_page_ready = AsyncMock(return_value=True)
-
-        with (
-            patch("src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator),
-            patch(
-                "src.scraper.qop_scraper.MLSConsentHandler", return_value=mock_consent
-            ),
-        ):
-            await scraper._navigate(page)
-
-        mock_navigator.navigate_to.assert_called_once()
-        mock_consent.handle_consent_banner.assert_called_once()
-        mock_consent.wait_for_page_ready.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_navigate_raises_on_navigation_failure(self, scraper):
-        """Should raise QoPScraperError when navigate_to returns False."""
-        page = AsyncMock()
-
-        mock_navigator = AsyncMock()
-        mock_navigator.navigate_to = AsyncMock(return_value=False)
-
-        with patch(
-            "src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator
-        ):
-            with pytest.raises(QoPScraperError, match="Failed to navigate"):
-                await scraper._navigate(page)
-
-    @pytest.mark.asyncio
-    async def test_navigate_continues_when_consent_fails(self, scraper):
-        """A failed consent banner should not raise — just log a warning."""
-        page = AsyncMock()
-
-        mock_navigator = AsyncMock()
-        mock_navigator.navigate_to = AsyncMock(return_value=True)
-
-        mock_consent = AsyncMock()
-        mock_consent.handle_consent_banner = AsyncMock(return_value=False)
-        mock_consent.wait_for_page_ready = AsyncMock(return_value=False)
-
-        with (
-            patch("src.scraper.qop_scraper.PageNavigator", return_value=mock_navigator),
-            patch(
-                "src.scraper.qop_scraper.MLSConsentHandler", return_value=mock_consent
-            ),
-        ):
-            # Should not raise despite consent + readiness failures
-            await scraper._navigate(page)
-
-
-# ---------------------------------------------------------------------------
-# _try_button_filter
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestTryButtonFilter:
-    """Tests for MLSQoPScraper._try_button_filter()."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_returns_true_when_direct_selector_matches(self, scraper):
-        """Should click and return True when query_selector finds a matching element."""
-        page = AsyncMock()
-        mock_el = AsyncMock()
-        mock_el.click = AsyncMock()
-
-        # First selector (button:has-text) hits
-        page.query_selector = AsyncMock(return_value=mock_el)
-        page.query_selector_all = AsyncMock(return_value=[])
-
-        result = await scraper._try_button_filter(page, "northeast")
-
-        assert result is True
-        mock_el.click.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_returns_true_via_broad_candidate_search(self, scraper):
-        """Should find a matching element via the broad candidate fallback."""
-        page = AsyncMock()
-        # Direct selectors find nothing
-        page.query_selector = AsyncMock(return_value=None)
-
-        # Candidate element whose text matches "northeast division"
-        candidate = AsyncMock()
-        candidate.text_content = AsyncMock(return_value="Northeast Division")
-        candidate.click = AsyncMock()
-
-        page.query_selector_all = AsyncMock(return_value=[candidate])
-
-        result = await scraper._try_button_filter(page, "northeast")
-
-        assert result is True
-        candidate.click.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_returns_false_when_no_match(self, scraper):
-        """Should return False when nothing matches."""
-        page = AsyncMock()
-        page.query_selector = AsyncMock(return_value=None)
-
-        non_matching = AsyncMock()
-        non_matching.text_content = AsyncMock(return_value="Unrelated Text")
-
-        page.query_selector_all = AsyncMock(return_value=[non_matching])
-
-        result = await scraper._try_button_filter(page, "northeast")
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_returns_false_on_broad_search_exception(self, scraper):
-        """Should return False (not raise) if query_selector_all itself throws."""
-        page = AsyncMock()
-        page.query_selector = AsyncMock(return_value=None)
-        page.query_selector_all = AsyncMock(side_effect=RuntimeError("dom error"))
-
-        result = await scraper._try_button_filter(page, "northeast")
-
-        assert result is False
-
-
-# ---------------------------------------------------------------------------
-# _extract_rankings — secondary selector fallback
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestExtractRankingsFallback:
-    """Tests for selector fallback logic in _extract_rankings."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_second_selector_when_first_times_out(self, scraper):
-        """First table selector timing out should cause the loop to try the next one."""
-        page = AsyncMock()
-
-        good_row = _make_row(1, "Club A", 10, 80.0, 75.0, 78.0)
+@pytest.mark.asyncio
+class TestFetchHtml:
+    async def test_retries_on_http_error_then_succeeds(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
 
         call_count = 0
 
-        async def wait_for_selector_stub(sel, timeout):
+        async def fake_get(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 1:
-                raise Exception("timeout")
-            # Second selector succeeds
-            return None
-
-        page.wait_for_selector = wait_for_selector_stub
-        page.query_selector_all = AsyncMock(return_value=[good_row])
-
-        rankings = await scraper._extract_rankings(page)
-
-        assert len(rankings) == 1
-        assert call_count >= 2  # at least two selector attempts
-
-    @pytest.mark.asyncio
-    async def test_select_division_button_path_called(self, scraper):
-        """_select_division takes the button path when _try_select_element returns False."""
-        page = AsyncMock()
-        page.wait_for_timeout = AsyncMock()
+            if call_count < 2:
+                raise httpx.ConnectError("boom")
+            request = httpx.Request("GET", MLSQoPScraper.ENDPOINT_URL)
+            return httpx.Response(200, text="<html>ok</html>", request=request)
 
         with (
-            patch.object(
-                scraper,
-                "_try_select_element",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch.object(
-                scraper,
-                "_try_button_filter",
-                new_callable=AsyncMock,
-                return_value=True,
-            ) as mock_btn,
+            patch("httpx.AsyncClient.get", side_effect=fake_get),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            await scraper._select_division(page)
+            html = await scraper._fetch_html()
 
-        mock_btn.assert_called_once()
-        page.wait_for_timeout.assert_called_once_with(1500)
+        assert "ok" in html
+        assert call_count == 2
 
+    async def test_raises_after_max_retries(self):
+        scraper = MLSQoPScraper(age_group="U14", division="Northeast")
 
-# ---------------------------------------------------------------------------
-# Exception-handler branches in _try_select_element and _try_button_filter
-# ---------------------------------------------------------------------------
+        async def always_fail(*args, **kwargs):
+            raise httpx.ConnectError("boom")
 
-
-@pytest.mark.unit
-class TestExceptionHandlerBranches:
-    """Cover the except branches that swallow errors and try the next selector."""
-
-    @pytest.fixture
-    def scraper(self):
-        return MLSQoPScraper(age_group="U14", division="Northeast")
-
-    @pytest.mark.asyncio
-    async def test_try_select_element_handles_query_selector_all_exception(
-        self, scraper
-    ):
-        """When query_selector_all raises, the loop should continue and return False."""
-        page = AsyncMock()
-        # Make every query_selector_all call raise so all selectors are exhausted
-        page.query_selector_all = AsyncMock(side_effect=RuntimeError("dom error"))
-
-        result = await scraper._try_select_element(page, "northeast")
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_try_button_filter_handles_query_selector_exception(self, scraper):
-        """When query_selector raises, the specific-selector loop continues."""
-        page = AsyncMock()
-        # Direct selectors raise; broad fallback returns empty
-        page.query_selector = AsyncMock(side_effect=RuntimeError("boom"))
-        page.query_selector_all = AsyncMock(return_value=[])
-
-        result = await scraper._try_button_filter(page, "northeast")
-
-        assert result is False
+        with (
+            patch("httpx.AsyncClient.get", side_effect=always_fail),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(QoPScraperError, match="attempts"):
+                await scraper._fetch_html()


### PR DESCRIPTION
## Summary

Fixes #60's QoP scraper — the Playwright-based implementation couldn't find the division filter, because the standings and filters live inside a `modular11.com` iframe with a structure different from the schedule iframe the match scraper uses.

While diagnosing, discovered the iframe fetches standings via a public HTTP endpoint that returns HTML directly:

```
GET https://www.modular11.com/public_schedule/league/get_teams
    ?tournament_type=league&UID_age=<id>&UID_gender=0&UID_event=12&list_type=53
```

Rewrite drops Playwright entirely and uses `httpx` + `BeautifulSoup`:
- Much faster (no browser startup in CronJob pods)
- More robust (no iframe chain, no Bootstrap Select interactions)
- Dynamically matches divisions by heading text instead of hardcoded `js-group` IDs, which differ per age group
- Handles age-prefixed headings (`U15 Northeast Division`)
- Skips `(Pro Player Pathway)` brackets unless explicitly requested
- Gracefully skips age groups that publish traditional standings (W/L/T) instead of QoP metrics — QoP rows have a distinct 4-stat layout

## Verified against live endpoint

| Query | Result |
|-------|--------|
| U14 Northeast | 22 teams, top: New York City FC (QoP=87.6) ✓ |
| U14 Mid-Atlantic | 17 teams ✓ |
| U14 Southeast | 16 teams ✓ |
| U14 Florida | 15 teams ✓ |
| U13 Northeast | 22 teams ✓ |
| U15 Northeast | Correctly reports "not a QoP division" |
| U14 Pacific | Correctly reports "division not found" |

## Test plan

- [x] 31 new/rewritten unit tests for `qop_scraper.py` (parser fixtures, init validation, scrape path with mocked HTTP, retry/error paths)
- [x] Full `tests/unit` suite: 562 passed, 11 skipped
- [x] `ruff check` + `ruff format` pass
- [x] End-to-end CLI dry-run against live endpoint prints clean Rich table

## After merge

match-scraper-agent's `uv.lock` needs to be bumped to pick up the fix — the cronjob image will pull the new library on its next build.

🤖 Generated with Claude Code