### PR TITLE
fix: Normalize QoP team names before POSTing to MT

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2212,6 +2212,12 @@ def rankings(
         console.print(f"[red]Scraping failed: {e}[/red]")
         raise typer.Exit(code=1) from e
 
+    # Normalize MLS Next names to the short forms MT uses (same mapping
+    # applied during match ingestion) so rankings resolve to existing
+    # MT teams instead of creating orphan entries.
+    for r in snapshot.rankings:
+        r.team_name = normalize_team_name_for_display(r.team_name)
+
     # Print Rich table
     table = Table(
         title=f"QoP Rankings — {snapshot.age_group} {snapshot.division} — Week of {snapshot.week_of}",

--- a/tests/unit/test_rankings_command.py
+++ b/tests/unit/test_rankings_command.py
@@ -290,6 +290,73 @@ class TestRankingsSuccessfulPost:
 # ---------------------------------------------------------------------------
 
 
+class TestRankingsTeamNameNormalization:
+    """Tests that the rankings command applies the same team-name mapping
+    used by match scraping before POSTing to MT."""
+
+    def _snapshot_with_ifa(self) -> QoPSnapshot:
+        return QoPSnapshot(
+            week_of=date(2026, 4, 13),
+            division="Northeast",
+            age_group="U14",
+            scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
+            rankings=[
+                QoPRanking(
+                    rank=13,
+                    team_name="Intercontinental Football Academy of New England",
+                    matches_played=16,
+                    att_score=74.7,
+                    def_score=74.4,
+                    qop_score=74.6,
+                ),
+            ],
+        )
+
+    def test_posted_team_name_is_normalized(self):
+        """POST body must contain the short MT-friendly name, not the raw MLS Next name."""
+        snapshot = self._snapshot_with_ifa()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        posted_json = mock_httpx.post.call_args.kwargs["json"]
+        assert posted_json["rankings"][0]["team_name"] == "IFA"
+
+    def test_dry_run_output_shows_normalized_name(self):
+        """Dry-run table should also display the normalized name."""
+        snapshot = self._snapshot_with_ifa()
+
+        with patch(
+            "src.cli.main.MLSQoPScraper",
+            return_value=_mock_scraper(snapshot),
+        ):
+            result = runner.invoke(app, ["rankings", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "IFA" in result.output
+
+
 class TestRankingsHttpError:
     """Tests for HTTP error responses from the API."""
 


### PR DESCRIPTION
## Summary
The `rankings` CLI was serializing raw MLS Next team names into the MT POST body — e.g. `Intercontinental Football Academy of New England`. MT stores that club under the short name `IFA` (the same short form produced by match ingestion), so the POST returned with `team_id: null` for that row and the QoP column on the standings page rendered blank for IFA.

Apply the existing `normalize_team_name_for_display()` mapping (the same one match scraping uses) to each ranking before the Rich table render and before the POST body is built, so what's displayed matches what's posted.

Deliberately **not** applying `apply_league_specific_team_name` (which would produce `IFA HG`) — the MT Homegrown team is stored as `IFA` without the suffix, and the match-scraper-agent's normalization path does the same.

## Test plan
- [x] New `TestRankingsTeamNameNormalization` class:
  - Asserts POST body contains `team_name: "IFA"` when the snapshot has the long MLS Next name
  - Asserts the dry-run table prints `IFA`
- [x] Full `tests/unit` suite passes (all dots, no failures)
- [x] Ruff check + format pass
- [ ] After merge, bump pin in match-scraper-agent and re-run the QoP CronJob to verify IFA resolves in MT

🤖 Generated with [Claude Code](https://claude.com/claude-code)