### PR TITLE
feat: QoP snapshot — rename week_of → detected_at, change-detection aware

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2220,7 +2220,7 @@ def rankings(
 
     # Print Rich table
     table = Table(
-        title=f"QoP Rankings — {snapshot.age_group} {snapshot.division} — Week of {snapshot.week_of}",
+        title=f"QoP Rankings — {snapshot.age_group} {snapshot.division} — Detected {snapshot.detected_at}",
         show_header=True,
         header_style="bold magenta",
     )
@@ -2264,10 +2264,18 @@ def rankings(
             timeout=30,
         )
         response.raise_for_status()
-        console.print(
-            f"[green]Posted {len(snapshot.rankings)} rankings to MT API"
-            f" for week of {snapshot.week_of} ✓[/green]"
-        )
+        payload = response.json() if response.content else {}
+        status = payload.get("status", "inserted")
+        if status == "unchanged":
+            console.print(
+                f"[yellow]MT reports no change since last snapshot "
+                f"(detected_at {payload.get('detected_at')}) — nothing written.[/yellow]"
+            )
+        else:
+            console.print(
+                f"[green]Posted {len(snapshot.rankings)} rankings to MT API"
+                f" as snapshot for {snapshot.detected_at} ✓[/green]"
+            )
     except httpx.HTTPStatusError as e:
         console.print(
             f"[red]HTTP error posting rankings: {e.response.status_code} {e.response.text}[/red]"

--- a/src/models/qop_ranking.py
+++ b/src/models/qop_ranking.py
@@ -30,10 +30,15 @@ class QoPRanking(BaseModel):
 
 
 class QoPSnapshot(BaseModel):
-    """A full weekly snapshot for a division/age-group."""
+    """A full snapshot for a division/age-group at a point in time."""
 
-    week_of: date = Field(
-        description="ISO date of the Monday that starts the week this snapshot was taken"
+    detected_at: date = Field(
+        description=(
+            "ISO date the scraper first observed this set of rankings. "
+            "MT keys snapshot identity on this date, so a re-scrape on the "
+            "same day with the same data is a no-op; a re-scrape with "
+            "different data on a later day lands as a new snapshot."
+        )
     )
     division: str = Field(description="Division name, e.g. 'Northeast'")
     age_group: str = Field(description="Age group, e.g. 'U14'")
@@ -58,10 +63,10 @@ class QoPSnapshot(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "week_of": "2026-04-14",
+                "detected_at": "2026-04-18",
                 "division": "Northeast",
                 "age_group": "U14",
-                "scraped_at": "2026-04-16T10:00:00Z",
+                "scraped_at": "2026-04-18T10:00:00Z",
                 "rankings": [
                     {
                         "rank": 1,

--- a/src/scraper/qop_scraper.py
+++ b/src/scraper/qop_scraper.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 import httpx
 from bs4 import BeautifulSoup, Tag
@@ -131,9 +131,6 @@ class MLSQoPScraper:
                 "publish standard league standings) or the page structure changed."
             )
 
-        today = date.today()
-        week_of = today - timedelta(days=today.weekday())
-
         logger.info(
             "QoP standings scrape completed",
             extra={
@@ -144,7 +141,7 @@ class MLSQoPScraper:
         )
 
         return QoPSnapshot(
-            week_of=week_of,
+            detected_at=date.today(),
             division=self.division,
             age_group=self.age_group,
             scraped_at=datetime.now(tz=timezone.utc),

--- a/tests/unit/test_qop_ranking.py
+++ b/tests/unit/test_qop_ranking.py
@@ -80,21 +80,21 @@ class TestQoPSnapshot:
 
     def test_valid_construction(self):
         snapshot = QoPSnapshot(
-            week_of=date(2026, 4, 14),
+            detected_at=date(2026, 4, 14),
             division="Northeast",
             age_group="U14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
             rankings=[self._make_ranking()],
         )
 
-        assert snapshot.week_of == date(2026, 4, 14)
+        assert snapshot.detected_at == date(2026, 4, 14)
         assert snapshot.division == "Northeast"
         assert snapshot.age_group == "U14"
         assert len(snapshot.rankings) == 1
 
     def test_division_normalized_to_title_case(self):
         snapshot = QoPSnapshot(
-            week_of=date(2026, 4, 14),
+            detected_at=date(2026, 4, 14),
             division="northeast",
             age_group="U14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
@@ -104,7 +104,7 @@ class TestQoPSnapshot:
 
     def test_age_group_normalized(self):
         snapshot = QoPSnapshot(
-            week_of=date(2026, 4, 14),
+            detected_at=date(2026, 4, 14),
             division="Northeast",
             age_group="u14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
@@ -114,7 +114,7 @@ class TestQoPSnapshot:
 
     def test_rankings_default_to_empty_list(self):
         snapshot = QoPSnapshot(
-            week_of=date(2026, 4, 14),
+            detected_at=date(2026, 4, 14),
             division="Northeast",
             age_group="U14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
@@ -124,7 +124,7 @@ class TestQoPSnapshot:
 
     def test_json_serialization_round_trip(self):
         original = QoPSnapshot(
-            week_of=date(2026, 4, 14),
+            detected_at=date(2026, 4, 14),
             division="Northeast",
             age_group="U14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),

--- a/tests/unit/test_qop_scraper.py
+++ b/tests/unit/test_qop_scraper.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -300,16 +300,15 @@ class TestScrape:
         assert len(snapshot.rankings) == 2
         assert snapshot.rankings[0].team_name == "New York City FC"
 
-    async def test_scrape_week_of_is_monday(self):
+    async def test_scrape_detected_at_is_today(self):
+        """detected_at is set to date.today() — it represents when the scraper
+        observed the rankings, not a wall-clock week boundary."""
         scraper = MLSQoPScraper(age_group="U14", division="Northeast")
         with patch.object(scraper, "_fetch_html", new_callable=AsyncMock) as mock_fetch:
             mock_fetch.return_value = _make_successful_html()
             snapshot = await scraper.scrape()
 
-        today = date.today()
-        expected_monday = today - timedelta(days=today.weekday())
-        assert snapshot.week_of == expected_monday
-        assert snapshot.week_of.weekday() == 0
+        assert snapshot.detected_at == date.today()
 
     async def test_scrape_raises_when_rankings_empty(self):
         scraper = MLSQoPScraper(age_group="U14", division="Northeast")

--- a/tests/unit/test_rankings_command.py
+++ b/tests/unit/test_rankings_command.py
@@ -18,7 +18,7 @@ runner = CliRunner()
 def _make_snapshot() -> QoPSnapshot:
     """Build a minimal QoPSnapshot for use in tests."""
     return QoPSnapshot(
-        week_of=date(2026, 4, 13),
+        detected_at=date(2026, 4, 13),
         division="Northeast",
         age_group="U14",
         scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),
@@ -290,13 +290,57 @@ class TestRankingsSuccessfulPost:
 # ---------------------------------------------------------------------------
 
 
+class TestRankingsUnchangedResponse:
+    """The rankings command should surface MT's `status: unchanged` reply
+    distinctly from a fresh insert."""
+
+    def test_unchanged_status_printed_when_mt_reports_no_change(self):
+        snapshot = _make_snapshot()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.content = b'{"status":"unchanged","detected_at":"2026-04-10"}'
+        mock_response.json.return_value = {
+            "status": "unchanged",
+            "detected_at": "2026-04-10",
+        }
+
+        with (
+            patch(
+                "src.cli.main.MLSQoPScraper",
+                return_value=_mock_scraper(snapshot),
+            ),
+            patch("src.cli.main.httpx") as mock_httpx,
+        ):
+            mock_httpx.post.return_value = mock_response
+            mock_httpx.HTTPStatusError = Exception
+
+            result = runner.invoke(
+                app,
+                [
+                    "rankings",
+                    "--api-token",
+                    "tok",
+                    "--api-url",
+                    "http://api.example.com",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Rich injects ANSI colour codes that break substring match on dashes/digits.
+        import re as _re
+
+        plain = _re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "no change" in plain.lower() or "unchanged" in plain.lower()
+        assert "2026-04-10" in plain
+
+
 class TestRankingsTeamNameNormalization:
     """Tests that the rankings command applies the same team-name mapping
     used by match scraping before POSTing to MT."""
 
     def _snapshot_with_ifa(self) -> QoPSnapshot:
         return QoPSnapshot(
-            week_of=date(2026, 4, 13),
+            detected_at=date(2026, 4, 13),
             division="Northeast",
             age_group="U14",
             scraped_at=datetime(2026, 4, 16, 10, 0, 0, tzinfo=timezone.utc),


### PR DESCRIPTION
## Summary

Pairs with [missing-table PR #306](https://github.com/silverbeer/missing-table/pull/306) which migrates the backend to a snapshot-centric QoP model keyed on the date the scraper observed the data. This PR updates the library to speak the new wire format.

## What changed

- `QoPSnapshot.week_of` → `detected_at`. The scraper computes `detected_at = date.today()` instead of "Monday of the current week" — so the natural key at the DB layer reflects when we saw the data, not a wall-clock week boundary. Same-day re-scrapes with identical payloads collide cleanly (MT no-ops); a later-day scrape with different data lands as a new snapshot.
- `rankings` CLI surfaces MT's new `{"status": "unchanged"}` response explicitly — prints a yellow "no change" notice instead of falsely reporting `Posted N rankings` when the backend didn't write anything.
- Rich-table title updated from "Week of …" to "Detected …" to match the semantics.

## Tests
- `test_qop_ranking.py` — field rename, all cases.
- `test_qop_scraper.py` — replaced `test_scrape_week_of_is_monday` with `test_scrape_detected_at_is_today`.
- `test_rankings_command.py` — field rename; new `TestRankingsUnchangedResponse` covers the no-op path end-to-end (mocked MT response asserts "no change" surfaces and the `detected_at` date is shown).
- Full `tests/unit` suite passes.

## Rollout coordination
MT PR #306 must deploy before this library change is consumed — otherwise POSTs fail schema validation. match-scraper-agent will bump the pin in a follow-up PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)