### PR TITLE
feat: Detect MLS Next schedule release for 2026-2027

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Run tests with reports
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          # Flatten "silverbeer/sb-499-foo" to "silverbeer-sb-499-foo": a slash
+          # would nest the report one level deeper than the index builder
+          # expects, feeding it a branch name where it wants a run number.
+          BRANCH="${BRANCH//\//-}"
           REPORT_DIR="site/reports/$BRANCH/${GITHUB_RUN_NUMBER}"
           mkdir -p "$REPORT_DIR"
 
@@ -66,6 +70,10 @@ jobs:
       - name: Generate diff coverage report
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          # Flatten "silverbeer/sb-499-foo" to "silverbeer-sb-499-foo": a slash
+          # would nest the report one level deeper than the index builder
+          # expects, feeding it a branch name where it wants a run number.
+          BRANCH="${BRANCH//\//-}"
           REPORT_DIR="site/reports/$BRANCH/${GITHUB_RUN_NUMBER}"
 
           # Generate diff coverage report for new code
@@ -103,6 +111,10 @@ jobs:
       - name: Prune old reports (keep last 5 per branch)
         run: |
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
+          # Flatten "silverbeer/sb-499-foo" to "silverbeer-sb-499-foo": a slash
+          # would nest the report one level deeper than the index builder
+          # expects, feeding it a branch name where it wants a run number.
+          BRANCH="${BRANCH//\//-}"
           REPORTS_DIR="site/reports/$BRANCH"
           mkdir -p "$REPORTS_DIR"
           cd "$REPORTS_DIR"
@@ -169,7 +181,6 @@ jobs:
             echo "<h2>📂 Branch: $branch</h2>" >> site/index.html
 
             for d in $(ls -1 site/reports/$branch | sort -nr | head -10); do
-              RUN_DATE=$(date -d "@$(($(date +%s) - ($(date +%s) - $d * 60)))" 2>/dev/null || echo "Run $d")
               echo "<div class=\"run\">" >> site/index.html
               echo "<a href=\"/$(basename $GITHUB_REPOSITORY)/reports/$branch/$d/\">🔗 Run #$d</a>" >> site/index.html
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Welcome to the documentation for the MLS Match Scraper library. This library pro
 ### 🏗️ Architecture
 - [Async Message Queue Architecture](architecture/async-message-queue-architecture.md) - **⭐ Educational guide to the complete pipeline** (match-scraper → RabbitMQ → Celery → Supabase)
 - [RabbitMQ Fanout Pattern: Dev/Prod](architecture/rabbitmq-fanout-dev-prod.md) - **NEW** Fanout exchange pattern for environment separation
+- [Season Rollover](architecture/season-rollover.md) - **NEW** What breaks when MLS Next starts a new season: division ID drift, derived season boundaries, and the modular11 HTTP endpoint
 - [Fix Summary](architecture/fix-summary.md) - Summary of architectural fixes and improvements
 
 ### 📘 Guides
@@ -63,6 +64,7 @@ docs/
 └── architecture/                # Architecture decisions
     ├── async-message-queue-architecture.md  # Complete pipeline guide
     ├── rabbitmq-fanout-dev-prod.md         # Dev/prod environment separation
+    ├── season-rollover.md      # New-season breakage and ID drift
     └── fix-summary.md          # Architectural improvements
 ```
 

--- a/docs/architecture/season-rollover.md
+++ b/docs/architecture/season-rollover.md
@@ -1,0 +1,113 @@
+# Season rollover
+
+What breaks when MLS Next starts a new season, and why. Written after the
+2025-2026 → 2026-2027 rollover (observed 2026-08-02, SB-499).
+
+## What the rollover actually did
+
+The MLS Next schedule page embeds a modular11 iframe. On rollover:
+
+- The iframe URL gained a new season token: `modular11.com/schedule?year=21`.
+- The **calendar widget stopped accepting prior-season dates**. Scraping
+  2025-09-05 through Playwright now fails with `Failed to navigate to start
+  date month` after four attempts.
+- The QoP standings endpoint began answering `There are no teams.` for every
+  age group — so the weekly QoP CronJob silently produced nothing.
+- Fixtures for the new season were not published for weeks after the rollover.
+  The page was up; it was simply empty.
+
+Two things did **not** change: the age-group IDs, and the tournament ID (`12`).
+
+## The three ID spaces, and why they must stay apart
+
+It is easy to treat these as one table. They are not.
+
+| Space | Lives in | Changes when |
+|-------|----------|--------------|
+| modular11 **age** IDs | `src/scraper/modular11.py` | MLS Next reorganises age groups |
+| modular11 **group** IDs (divisions) | `src/scraper/modular11.py` | MLS Next reorganises divisions — **it did in 2026-2027** |
+| missing-table **division** IDs | `src/utils/division_lookup.py` | Only when *our* database changes |
+
+For 2026-2027 the site renumbered several divisions:
+
+| Division | 2025-2026 | 2026-2027 |
+|----------|-----------|-----------|
+| Southeast | 37 | **45** |
+| Southwest | 36 | **52** |
+| Northwest | 38 | **57** |
+| Great Lakes / Texas / California | 39 / 40 / 42 | *removed* |
+| West / Frontier / Mid-America / MLS Academy | — | 33 / 66 / 67 / 225 |
+
+Northeast (41), Florida (46), Mid-Atlantic (68), Central (34) and East (35)
+were unchanged, which is why the divisions we scrape kept working.
+
+**`division_lookup.DIVISION_ID_MAP` was seeded from the site's IDs and still
+carries the old values.** That is deliberate: those integers are posted to
+missing-table as `division_id`, so changing them to match the site would point
+at divisions missing-table does not have. Before scraping Southeast, Southwest
+or Northwest, reconcile the two maps explicitly — do not copy one into the
+other.
+
+## Derive season boundaries, never pin them
+
+Three constants were pinned to literal years and all three went stale at once:
+
+- `division_discovery.SEASON_START/SEASON_END` (2025-09-01 → 2026-06-30)
+- `cli.main.build_match_dict`'s `"season": "2024-25"` — two seasons behind
+- `match-scraper-agent`'s `SEASON_END = date(2026, 6, 30)`
+
+All season maths now comes from `src/scraper/modular11.py`:
+
+```python
+current_season_year(date(2027, 3, 1))  # 2026 — March belongs to 2026-2027
+season_label(2026)                     # '2026-2027'
+season_window(2026)                    # (2026-08-01, 2027-07-15)
+fall_segment_window(2026)              # (2026-08-01, 2026-12-31)
+```
+
+The season starts in August and ends mid-July; those bounds mirror the default
+`start_date`/`end_date` the modular11 iframe sends for itself.
+
+Season labels use the four-four form (`2026-2027`), matching what
+match-scraper-agent posts. The old `2024-25` form in this repo was a
+divergence, not a second supported format.
+
+## The HTTP endpoint behind the iframe
+
+The iframe fetches fixtures from a plain GET endpoint — no browser required:
+
+```
+GET https://www.modular11.com/public_schedule/league/get_matches
+    ?tournament=12&age[]=33&groups[]=41&status=all&match_type=2
+    &start_date=2026-08-01 00:00:00&end_date=2027-07-15 23:59:59
+    &open_page=0&academy=0&gender=0&brackets=&group=&match_number=0
+    &schedule=0&teamPlayer=0&location=0&as_referee=0&report_status=0
+```
+
+Notes learned the hard way:
+
+- `status` must be one of `all`, `scheduled`, `pending`. Anything else returns
+  a red error fragment, not an HTTP error.
+- Results paginate at 25 rows. Counting rows answers "are there fixtures?",
+  not "how many?".
+- Pre-release the response is `No data available.` in about 70 bytes.
+- **Prior-season data is still served here** even though the calendar UI
+  refuses those dates. The Playwright block is a UI limitation, not a data one,
+  so a backfill path still exists via this endpoint.
+
+`src/scraper/release_detector.py` uses this to answer "has the schedule been
+published?" in about a second across 18 targets. See
+[`cli-usage.md`](../guides/cli-usage.md) for the `poll-release` command.
+
+## Rollover checklist
+
+When the season turns over:
+
+1. Run `mls-scraper poll-release` — confirms whether fixtures exist yet.
+2. Re-read `select[js-groups]` on `modular11.com/schedule?year=<token>` and
+   diff against `DIVISION_GROUP_IDS`.
+3. Check `select[js-age]` against `AGE_GROUP_IDS`.
+4. Confirm the QoP endpoint returns teams again before trusting the QoP
+   CronJob's output.
+5. Run `discover` + `enrich` for any division whose clubs are not yet in
+   missing-table.

--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -198,14 +198,69 @@ uv run mls-scraper inspect
 uv run mls-scraper inspect --no-headless --timeout 300
 ```
 
+### `poll-release` - Has the schedule been published yet?
+
+Checks whether MLS Next has published fixtures for a season. Queries the
+modular11 fixtures endpoint over plain HTTP — no browser, about a second for the
+default 18 targets — so it is cheap enough to run on a poll interval while
+waiting for a schedule to drop.
+
+```bash
+# Default: U15-first across Northeast, Florida and Mid-Atlantic, fall segment
+uv run mls-scraper poll-release
+
+# One target, whole season
+uv run mls-scraper poll-release -a U15 -d Northeast --full-season
+
+# Machine-readable, for a CronJob wrapper
+uv run mls-scraper poll-release --json --state-file /data/release-probe.ndjson
+```
+
+Expected output before a release:
+
+```
+MLS Next schedule — 2026-2027 (2026-08-01 → 2026-12-31)
+┏━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┓
+┃ Age ┃ Division     ┃ State ┃ Fixtures ┃
+┡━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━┩
+│ U15 │ Northeast    │ empty │        0 │
+│ ... │              │       │          │
+└─────┴──────────────┴───────┴──────────┘
+No fixtures published yet.
+```
+
+**Exit codes** are the notification contract for an unattended caller:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Nothing new — no fixtures yet, or fixtures already known |
+| `10` | Newly published fixtures for at least one target — notify! |
+| `20` | Every target failed to probe — notify if it persists |
+
+`--state-file` is what makes "newly" meaningful. Targets already recorded as
+live in that NDJSON file do not re-trigger exit `10`, so a scheduled poll alerts
+once on release rather than on every run. A missing or corrupt state file is
+treated as "nothing seen yet" — the poller keeps working rather than crashing.
+
+Note that `Fixtures` is a lower bound: the endpoint paginates at 25 rows, so the
+count answers "are there fixtures?", not "how many?".
+
 ## 🎯 Available Options
 
 ### Age Groups
-- U13, U14, U15, U16, U17, U18, U19
+- U13, U14, U15, U16, U17, U19
 
 ### Divisions
-- Northeast, Southeast, Central, Southwest, Northwest
-- Mid-Atlantic, Great Lakes, Texas, California
+As read from the live site for the 2026-2027 season:
+
+- **Scraped today:** Northeast, Florida, Mid-Atlantic
+- Also present: Central, East, Frontier, Mid-America, MLS Academy, Northwest,
+  Southeast, Southwest, West
+
+Division IDs are not stable across seasons — Southeast, Southwest and Northwest
+were all renumbered for 2026-2027, and Great Lakes, Texas and California no
+longer exist as groups. `src/scraper/modular11.py` holds the site-side IDs and
+is the file to update when they move.
 
 ## 🛠️ Shortcut Script
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -35,9 +35,15 @@ from src.cli.env_config import (  # noqa: E402
     validate_config,
 )
 from src.models.audit import RunMetadata, RunSummary  # noqa: E402
+from src.models.schedule_release import (  # noqa: E402
+    DivisionRelease,
+    ReleaseProbe,
+    ReleaseState,
+)
 from src.scraper.config import ScrapingConfig  # noqa: E402
 from src.scraper.mls_scraper import MLSScraper, MLSScraperError  # noqa: E402
 from src.scraper.models import Match  # noqa: E402
+from src.scraper.modular11 import current_season_year, season_label  # noqa: E402
 from src.scraper.qop_scraper import MLSQoPScraper  # noqa: E402
 from src.utils.audit_logger import AuditLogger  # noqa: E402
 from src.utils.division_lookup import get_division_id_for_league  # noqa: E402
@@ -593,7 +599,14 @@ def build_match_dict(match: Match, config: ScrapingConfig) -> dict:
         if match.match_datetime
         and (match.match_datetime.hour or match.match_datetime.minute)
         else None,
-        "season": "2024-25",  # TODO: derive from match date
+        # Derived from the match date, not the wall clock: a match played in
+        # September belongs to the season starting that August even if it is
+        # re-scraped the following spring.
+        "season": season_label(
+            current_season_year(
+                match.match_datetime.date() if match.match_datetime else date.today()
+            )
+        ),
         "age_group": config.age_group,
         "match_type": "League",
         "division": division_name,
@@ -2641,6 +2654,190 @@ def enrich(
     except Exception as e:
         handle_cli_error(e, verbose)
         raise typer.Exit(code=1) from None
+
+
+@app.command("poll-release")
+def poll_release(
+    age_groups: Optional[list[str]] = typer.Option(
+        None,
+        "--age-group",
+        "-a",
+        help="Age group to check; repeat for several. Defaults to all six, U15 first.",
+    ),
+    divisions: Optional[list[str]] = typer.Option(
+        None,
+        "--division",
+        "-d",
+        help="Division to check; repeat for several. Defaults to Northeast, Florida, Mid-Atlantic.",
+    ),
+    season_year: Optional[int] = typer.Option(
+        None,
+        "--season-year",
+        help="Season start year (2026 = the 2026-2027 season). Defaults to the current season.",
+    ),
+    full_season: bool = typer.Option(
+        False,
+        "--full-season",
+        help="Search the whole season instead of just the fall segment.",
+    ),
+    state_file: Optional[Path] = typer.Option(
+        None,
+        "--state-file",
+        help="NDJSON file to append each probe to, and to read prior state from.",
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit the probe as JSON on stdout instead of a table."
+    ),
+) -> None:
+    """
+    📡 Check whether MLS Next has published its schedule yet.
+
+    Queries the modular11 fixtures endpoint directly — no browser, roughly one
+    second for the default 18 targets — so it is cheap enough to run on a poll
+    interval while waiting for a release.
+
+    Exit codes are the notification contract for an unattended caller:
+
+    \b
+      0  nothing new — either no fixtures yet, or already-known fixtures
+      10 newly published fixtures for at least one target (notify!)
+      20 every target failed to probe (notify if it persists)
+
+    Passing --state-file makes "newly" meaningful: targets already recorded as
+    live in that file do not re-trigger exit 10, so a CronJob alerts once on
+    release rather than on every run.
+    """
+    setup_environment()
+
+    from src.scraper.release_detector import (  # noqa: PLC0415
+        ReleaseDetectorError,
+        ScheduleReleaseDetector,
+    )
+
+    try:
+        detector = ScheduleReleaseDetector(
+            age_groups=age_groups or None,
+            divisions=divisions or None,
+            season_year=season_year,
+            fall_only=not full_season,
+        )
+        probe = asyncio.run(detector.probe())
+    except ReleaseDetectorError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from e
+
+    previously_live = _load_live_targets(state_file)
+    newly_live = [r for r in probe.live if r.label not in previously_live]
+
+    if as_json:
+        payload = probe.model_dump(mode="json")
+        payload["newly_live"] = [r.label for r in newly_live]
+        # Plain stdout, not console.print_json: Rich would wrap this in ANSI
+        # colour codes, and the point of --json is to be piped into jq.
+        typer.echo(json.dumps(payload))
+    else:
+        _display_release_probe(probe, newly_live)
+
+    if state_file is not None:
+        _append_probe_state(state_file, probe, newly_live)
+
+    if probe.all_failed:
+        raise typer.Exit(code=20)
+    if newly_live:
+        raise typer.Exit(code=10)
+
+
+def _load_live_targets(state_file: Optional[Path]) -> set[str]:
+    """
+    Read the set of targets already seen live from a probe NDJSON file.
+
+    A missing or malformed file is treated as "nothing seen yet" — a poller
+    that alerts twice is a nuisance, but one that crashes on a bad line stops
+    alerting altogether, which is worse.
+    """
+    if state_file is None or not state_file.exists():
+        return set()
+
+    seen: set[str] = set()
+    try:
+        with state_file.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for result in record.get("results", []):
+                    if result.get("state") == "live":
+                        seen.add(f"{result['age_group']} {result['division']}")
+    except OSError:
+        return set()
+
+    return seen
+
+
+def _append_probe_state(
+    state_file: Path, probe: ReleaseProbe, newly_live: list[DivisionRelease]
+) -> None:
+    """Append one probe to the NDJSON state file, creating parents as needed."""
+    record = probe.model_dump(mode="json")
+    record["newly_live"] = [r.label for r in newly_live]
+
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        with state_file.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as e:
+        console.print(f"[yellow]Warning: could not write state file: {e}[/yellow]")
+
+
+def _display_release_probe(
+    probe: ReleaseProbe, newly_live: list[DivisionRelease]
+) -> None:
+    """Render a probe as a Rich table plus a one-line verdict."""
+    table = Table(
+        title=f"MLS Next schedule — {probe.season} "
+        f"({probe.window_start} → {probe.window_end})",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Age", style="cyan")
+    table.add_column("Division")
+    table.add_column("State")
+    table.add_column("Fixtures", justify="right")
+
+    styles = {
+        ReleaseState.LIVE: "[bold green]live[/bold green]",
+        ReleaseState.EMPTY: "[dim]empty[/dim]",
+        ReleaseState.ERROR: "[bold red]error[/bold red]",
+    }
+    new_labels = {r.label for r in newly_live}
+
+    for r in probe.results:
+        marker = " [bold yellow]NEW[/bold yellow]" if r.label in new_labels else ""
+        table.add_row(
+            r.age_group,
+            r.division,
+            styles[r.state] + marker,
+            str(r.match_count) if r.state is not ReleaseState.ERROR else "—",
+        )
+
+    console.print(table)
+
+    if probe.all_failed:
+        console.print("[bold red]All targets failed to probe.[/bold red]")
+    elif newly_live:
+        labels = ", ".join(sorted(new_labels))
+        console.print(f"[bold green]🎉 Schedule published for: {labels}[/bold green]")
+    elif probe.is_released:
+        console.print("[green]Fixtures live (already known).[/green]")
+    else:
+        console.print("[dim]No fixtures published yet.[/dim]")
+
+    for r in probe.errors:
+        console.print(f"[red]{r.label}: {r.error}[/red]")
 
 
 if __name__ == "__main__":

--- a/src/models/schedule_release.py
+++ b/src/models/schedule_release.py
@@ -1,0 +1,158 @@
+"""
+Models describing whether an MLS Next schedule has been published yet.
+
+A release probe answers one question per (age group, division) pair: has MLS
+Next published fixtures for this season? The page is up year-round, so "up" is
+not the signal — fixture count is. The probe distinguishes three states so an
+unattended poller can stay quiet on the boring ones:
+
+* ``EMPTY``   — endpoint healthy, zero fixtures. The normal pre-release state.
+* ``LIVE``    — fixtures published. This is the state worth waking someone for.
+* ``ERROR``   — endpoint unreachable or unparseable. Worth alerting on only if
+  it persists, since a single blip is not news.
+"""
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ReleaseState(str, Enum):
+    """Publication state of a single age-group/division schedule."""
+
+    EMPTY = "empty"
+    LIVE = "live"
+    ERROR = "error"
+
+
+class DivisionRelease(BaseModel):
+    """Publication state for one age group within one division."""
+
+    age_group: str = Field(..., description="Age group, e.g. 'U15'")
+    division: str = Field(..., description="Division name, e.g. 'Northeast'")
+    state: ReleaseState = Field(..., description="Publication state")
+    match_count: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Fixtures on the first page of results. The endpoint paginates at "
+            "25 rows, so this is a lower bound on the season total, not the "
+            "total itself — enough to decide 'published or not', not enough to "
+            "report volume."
+        ),
+    )
+    error: Optional[str] = Field(
+        default=None, description="Failure detail when state is 'error'"
+    )
+
+    @field_validator("age_group")
+    @classmethod
+    def normalize_age_group(cls, v: str) -> str:
+        v = v.strip().upper()
+        if not v:
+            raise ValueError("age_group cannot be empty")
+        return v
+
+    @field_validator("division")
+    @classmethod
+    def normalize_division(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("division cannot be empty")
+        return v
+
+    @property
+    def is_live(self) -> bool:
+        """True when fixtures have been published for this target."""
+        return self.state is ReleaseState.LIVE
+
+    @property
+    def label(self) -> str:
+        """Human-readable target name, e.g. ``'U15 Northeast'``."""
+        return f"{self.age_group} {self.division}"
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "age_group": "U15",
+                "division": "Northeast",
+                "state": "live",
+                "match_count": 128,
+                "error": None,
+            }
+        }
+
+
+class ReleaseProbe(BaseModel):
+    """The full result of one poll across every target."""
+
+    season: str = Field(..., description="Season identifier, e.g. '2026-2027'")
+    window_start: date = Field(..., description="First date searched for fixtures")
+    window_end: date = Field(..., description="Last date searched for fixtures")
+    checked_at: datetime = Field(..., description="When the poll ran (UTC)")
+    results: list[DivisionRelease] = Field(
+        default_factory=list, description="One entry per age group/division probed"
+    )
+
+    @property
+    def live(self) -> list[DivisionRelease]:
+        """Targets whose fixtures have been published."""
+        return [r for r in self.results if r.state is ReleaseState.LIVE]
+
+    @property
+    def errors(self) -> list[DivisionRelease]:
+        """Targets whose probe failed."""
+        return [r for r in self.results if r.state is ReleaseState.ERROR]
+
+    @property
+    def total_matches(self) -> int:
+        """Fixtures found across all targets."""
+        return sum(r.match_count for r in self.results)
+
+    @property
+    def is_released(self) -> bool:
+        """True when at least one target has published fixtures."""
+        return bool(self.live)
+
+    @property
+    def all_failed(self) -> bool:
+        """
+        True when every target errored.
+
+        Distinguishes "MLS Next is down" from "the schedule isn't out yet" —
+        an all-empty probe is expected, an all-error probe is not.
+        """
+        return bool(self.results) and len(self.errors) == len(self.results)
+
+    def summary(self) -> str:
+        """One-line human summary suitable for a log or a Telegram message."""
+        if self.all_failed:
+            return f"{self.season}: all {len(self.results)} targets failed to probe"
+        if not self.is_released:
+            return f"{self.season}: no fixtures yet across {len(self.results)} targets"
+        parts = [f"{r.label} ({r.match_count})" for r in self.live]
+        return (
+            f"{self.season}: fixtures live for {len(self.live)}/{len(self.results)} "
+            f"targets — {', '.join(parts)}"
+        )
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "season": "2026-2027",
+                "window_start": "2026-08-01",
+                "window_end": "2026-12-31",
+                "checked_at": "2026-08-07T12:00:00Z",
+                "results": [
+                    {
+                        "age_group": "U15",
+                        "division": "Northeast",
+                        "state": "live",
+                        "match_count": 128,
+                        "error": None,
+                    }
+                ],
+            }
+        }

--- a/src/scraper/division_discovery.py
+++ b/src/scraper/division_discovery.py
@@ -4,21 +4,21 @@ Discovers clubs and teams in a given division by scraping match data
 across all age groups and extracting unique team names.
 """
 
-from datetime import date
-
 from ..models.discovery import DiscoveredClub, DiscoveredTeam
 from ..utils.logger import get_logger
 from .config import ScrapingConfig
 from .mls_scraper import MLSScraper, MLSScraperError
+from .modular11 import current_season_year, season_window
 
 logger = get_logger()
 
 # Standard HG age groups on MLS Next
 DISCOVERY_AGE_GROUPS = ["U13", "U14", "U15", "U16", "U17", "U19"]
 
-# Full season date range for discovery (cast the widest net)
-SEASON_START = date(2025, 9, 1)
-SEASON_END = date(2026, 6, 30)
+# Full season date range for discovery (cast the widest net). Derived rather
+# than hardcoded — a pinned range silently discovers nothing once the season
+# rolls over, which is exactly how the 2025-2026 constants went stale.
+SEASON_START, SEASON_END = season_window(current_season_year())
 
 
 class DivisionDiscoverer:

--- a/src/scraper/modular11.py
+++ b/src/scraper/modular11.py
@@ -1,0 +1,129 @@
+"""
+Site-side constants and helpers for the modular11 backend behind MLS Next.
+
+The MLS Next schedule page (``mlssoccer.com/mlsnext/schedule/all/``) embeds a
+modular11 iframe whose filters are driven by numeric IDs. Those same IDs drive
+the ``public_schedule/league/get_matches`` HTTP endpoint, which returns the
+fixture list as an HTML fragment without any browser automation.
+
+Two ID spaces are easy to confuse and are deliberately kept apart:
+
+* **modular11 group IDs** (this module) describe the *website* and change when
+  MLS Next reorganises its divisions between seasons.
+* **missing-table division IDs** (``src.utils.division_lookup``) describe our
+  own database and must stay stable regardless of what the website does.
+
+They currently agree for the divisions we scrape, but they are not the same
+thing and must not be edited as if they were.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+# MLS NEXT tournament ID on modular11. Stable across the seasons observed so far.
+TOURNAMENT_ID = "12"
+
+# Age group → modular11 ``age[]`` value. Verified unchanged for 2026-2027.
+AGE_GROUP_IDS: dict[str, str] = {
+    "U13": "21",
+    "U14": "22",
+    "U15": "33",
+    "U16": "14",
+    "U17": "15",
+    "U19": "26",
+}
+
+# Division name → modular11 ``groups[]`` value, read from the live
+# ``select[js-groups]`` on 2026-08-02 for the 2026-2027 season.
+#
+# NOTE: several IDs changed from the 2025-2026 season — Southeast 37→45,
+# Southwest 36→52, Northwest 38→57 — and Great Lakes, Texas and California no
+# longer exist as groups. The divisions we scrape (Northeast, Florida,
+# Mid-Atlantic) are unchanged. Do not copy these values into
+# ``division_lookup.DIVISION_ID_MAP``; that map addresses missing-table, not
+# modular11.
+DIVISION_GROUP_IDS: dict[str, str] = {
+    "Central": "34",
+    "East": "35",
+    "Florida": "46",
+    "Frontier": "66",
+    "Mid-America": "67",
+    "Mid-Atlantic": "68",
+    "MLS Academy": "225",
+    "Northeast": "41",
+    "Northwest": "57",
+    "Southeast": "45",
+    "Southwest": "52",
+    "West": "33",
+}
+
+# Divisions prioritised for the 2026-2027 fall segment.
+PRIORITY_DIVISIONS: tuple[str, ...] = ("Northeast", "Florida", "Mid-Atlantic")
+
+# Age groups in priority order — U15 first, per SB-499.
+PRIORITY_AGE_GROUPS: tuple[str, ...] = ("U15", "U13", "U14", "U16", "U17", "U19")
+
+# The season runs August → mid-July. These bounds mirror the default
+# ``start_date``/``end_date`` the modular11 iframe sends for itself.
+SEASON_START_MONTH = 8
+SEASON_START_DAY = 1
+SEASON_END_MONTH = 7
+SEASON_END_DAY = 15
+
+
+def current_season_year(today: date | None = None) -> int:
+    """
+    Return the starting year of the season containing ``today``.
+
+    August or later belongs to the season starting that year; January through
+    July belongs to the season that started the previous year.
+
+    >>> current_season_year(date(2026, 8, 2))
+    2026
+    >>> current_season_year(date(2027, 3, 1))
+    2026
+    """
+    today = today or date.today()
+    return today.year if today.month >= SEASON_START_MONTH else today.year - 1
+
+
+def season_label(season_year: int) -> str:
+    """
+    Return the missing-table season identifier for a season start year.
+
+    >>> season_label(2026)
+    '2026-2027'
+    """
+    return f"{season_year}-{season_year + 1}"
+
+
+def current_season_label(today: date | None = None) -> str:
+    """Return the season identifier covering ``today``, e.g. ``'2026-2027'``."""
+    return season_label(current_season_year(today))
+
+
+def season_window(season_year: int) -> tuple[date, date]:
+    """
+    Return the ``(start, end)`` dates bounding a season.
+
+    >>> season_window(2026)
+    (datetime.date(2026, 8, 1), datetime.date(2027, 7, 15))
+    """
+    return (
+        date(season_year, SEASON_START_MONTH, SEASON_START_DAY),
+        date(season_year + 1, SEASON_END_MONTH, SEASON_END_DAY),
+    )
+
+
+def fall_segment_window(season_year: int) -> tuple[date, date]:
+    """
+    Return the ``(start, end)`` dates bounding a season's fall segment.
+
+    The fall segment runs from the season start through the end of the calendar
+    year; the spring segment picks up in January.
+    """
+    return (
+        date(season_year, SEASON_START_MONTH, SEASON_START_DAY),
+        date(season_year, 12, 31),
+    )

--- a/src/scraper/release_detector.py
+++ b/src/scraper/release_detector.py
@@ -1,0 +1,261 @@
+"""
+Detect whether MLS Next has published its schedule for a season.
+
+Hits the modular11 ``get_matches`` endpoint that the schedule iframe uses
+internally — the same source the Playwright scraper reads, minus the browser.
+A probe costs one HTTP request per age group/division pair, which makes it
+cheap enough to run on a short poll interval while waiting for a release.
+
+Before publication the endpoint answers ``No data available.`` in about 70
+bytes; afterwards it returns one ``[js-match-game]`` element per fixture. That
+difference is the whole signal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from datetime import date, datetime, timezone
+
+import httpx
+from bs4 import BeautifulSoup
+
+from ..models.schedule_release import DivisionRelease, ReleaseProbe, ReleaseState
+from ..utils.logger import get_logger
+from .modular11 import (
+    AGE_GROUP_IDS,
+    DIVISION_GROUP_IDS,
+    PRIORITY_AGE_GROUPS,
+    PRIORITY_DIVISIONS,
+    TOURNAMENT_ID,
+    current_season_year,
+    fall_segment_window,
+    season_label,
+    season_window,
+)
+
+logger = get_logger()
+
+# The endpoint returns this fragment when the season has no fixtures yet.
+EMPTY_MARKER = "no data available"
+
+# Each fixture row carries this attribute; counting them counts matches.
+MATCH_ROW_SELECTOR = "[js-match-game]"
+
+
+class ReleaseDetectorError(Exception):
+    """Raised when a probe cannot be completed at all."""
+
+
+class ScheduleReleaseDetector:
+    """
+    Polls modular11 for published fixtures across age groups and divisions.
+
+    Usage::
+
+        detector = ScheduleReleaseDetector()
+        probe = await detector.probe()
+        if probe.is_released:
+            ...
+    """
+
+    ENDPOINT_URL = "https://www.modular11.com/public_schedule/league/get_matches"
+
+    REQUEST_TIMEOUT = 30.0
+    MAX_RETRIES = 3
+    RETRY_DELAY_BASE = 1.0
+    RETRY_BACKOFF_MULTIPLIER = 2.0
+
+    # Keep concurrent requests modest — this runs unattended against someone
+    # else's server, and a release-day poll is not latency-sensitive.
+    MAX_CONCURRENCY = 4
+
+    def __init__(
+        self,
+        age_groups: Iterable[str] | None = None,
+        divisions: Iterable[str] | None = None,
+        season_year: int | None = None,
+        fall_only: bool = True,
+    ) -> None:
+        self.age_groups = list(age_groups or PRIORITY_AGE_GROUPS)
+        self.divisions = list(divisions or PRIORITY_DIVISIONS)
+        self.season_year = (
+            season_year if season_year is not None else current_season_year()
+        )
+        self.fall_only = fall_only
+
+        unknown_ages = [a for a in self.age_groups if a not in AGE_GROUP_IDS]
+        if unknown_ages:
+            raise ReleaseDetectorError(
+                f"Unknown age groups: {unknown_ages}. Known: {sorted(AGE_GROUP_IDS)}"
+            )
+
+        unknown_divs = [d for d in self.divisions if d not in DIVISION_GROUP_IDS]
+        if unknown_divs:
+            raise ReleaseDetectorError(
+                f"Unknown divisions: {unknown_divs}. "
+                f"Known: {sorted(DIVISION_GROUP_IDS)}"
+            )
+
+    @property
+    def window(self) -> tuple[date, date]:
+        """The date range searched for fixtures."""
+        if self.fall_only:
+            return fall_segment_window(self.season_year)
+        return season_window(self.season_year)
+
+    async def probe(self) -> ReleaseProbe:
+        """Check every age group/division pair and return the combined result."""
+        start, end = self.window
+        targets = [(a, d) for d in self.divisions for a in self.age_groups]
+
+        logger.info(
+            "Starting schedule release probe",
+            extra={
+                "season": season_label(self.season_year),
+                "targets": len(targets),
+                "window_start": start.isoformat(),
+                "window_end": end.isoformat(),
+            },
+        )
+
+        semaphore = asyncio.Semaphore(self.MAX_CONCURRENCY)
+
+        async with httpx.AsyncClient(timeout=self.REQUEST_TIMEOUT) as client:
+
+            async def run(age_group: str, division: str) -> DivisionRelease:
+                async with semaphore:
+                    return await self._check_target(
+                        client, age_group, division, start, end
+                    )
+
+            results = await asyncio.gather(*(run(age, div) for age, div in targets))
+
+        probe = ReleaseProbe(
+            season=season_label(self.season_year),
+            window_start=start,
+            window_end=end,
+            checked_at=datetime.now(tz=timezone.utc),
+            results=list(results),
+        )
+
+        logger.info(
+            "Schedule release probe completed",
+            extra={
+                "season": probe.season,
+                "released": probe.is_released,
+                "live_targets": len(probe.live),
+                "error_targets": len(probe.errors),
+                "total_matches": probe.total_matches,
+            },
+        )
+
+        return probe
+
+    async def _check_target(
+        self,
+        client: httpx.AsyncClient,
+        age_group: str,
+        division: str,
+        start: date,
+        end: date,
+    ) -> DivisionRelease:
+        """Probe a single age group/division pair, converting failure to a result."""
+        try:
+            html = await self._fetch(client, age_group, division, start, end)
+        except Exception as exc:  # noqa: BLE001 — a failed target must not sink the probe
+            logger.warning(
+                "Release probe target failed",
+                extra={
+                    "age_group": age_group,
+                    "division": division,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return DivisionRelease(
+                age_group=age_group,
+                division=division,
+                state=ReleaseState.ERROR,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        count = count_matches(html)
+        return DivisionRelease(
+            age_group=age_group,
+            division=division,
+            state=ReleaseState.LIVE if count else ReleaseState.EMPTY,
+            match_count=count,
+        )
+
+    async def _fetch(
+        self,
+        client: httpx.AsyncClient,
+        age_group: str,
+        division: str,
+        start: date,
+        end: date,
+    ) -> str:
+        """GET the fixtures fragment for one target, with backoff."""
+        params = [
+            ("open_page", "0"),
+            ("academy", "0"),
+            ("tournament", TOURNAMENT_ID),
+            ("gender", "0"),
+            ("age[]", AGE_GROUP_IDS[age_group]),
+            ("brackets", ""),
+            ("groups[]", DIVISION_GROUP_IDS[division]),
+            ("group", ""),
+            ("match_number", "0"),
+            # The endpoint rejects anything outside all/scheduled/pending.
+            ("status", "all"),
+            ("match_type", "2"),
+            ("schedule", "0"),
+            ("teamPlayer", "0"),
+            ("location", "0"),
+            ("as_referee", "0"),
+            ("report_status", "0"),
+            ("start_date", f"{start.isoformat()} 00:00:00"),
+            ("end_date", f"{end.isoformat()} 23:59:59"),
+        ]
+        headers = {
+            "User-Agent": "Mozilla/5.0 (compatible; mls-match-scraper/release-detector)",
+            "X-Requested-With": "XMLHttpRequest",
+            "Accept": "text/html,*/*",
+        }
+
+        last_exc: Exception | None = None
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                resp = await client.get(
+                    self.ENDPOINT_URL, params=params, headers=headers
+                )
+                resp.raise_for_status()
+                return resp.text
+            except (httpx.HTTPError, httpx.RequestError) as exc:
+                last_exc = exc
+                if attempt < self.MAX_RETRIES - 1:
+                    await asyncio.sleep(
+                        self.RETRY_DELAY_BASE * (self.RETRY_BACKOFF_MULTIPLIER**attempt)
+                    )
+
+        raise ReleaseDetectorError(
+            f"get_matches failed after {self.MAX_RETRIES} attempts: {last_exc}"
+        ) from last_exc
+
+
+def count_matches(html: str) -> int:
+    """
+    Count fixture rows in a ``get_matches`` HTML fragment.
+
+    Returns 0 for the pre-release "No data available." response, so callers can
+    treat "empty" and "not yet published" as the same thing.
+
+    The endpoint paginates at 25 rows, so a full division saturates this count.
+    It answers "are there fixtures?", not "how many fixtures are there?".
+    """
+    if not html or not html.strip():
+        return 0
+    if EMPTY_MARKER in html.lower():
+        return 0
+    return len(BeautifulSoup(html, "html.parser").select(MATCH_ROW_SELECTOR))

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -3,7 +3,7 @@
 import json
 import os
 import tempfile
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,6 +17,7 @@ from src.scraper.division_discovery import (
 )
 from src.scraper.mls_scraper import MLSScraperError
 from src.scraper.models import Match
+from src.scraper.modular11 import current_season_year
 
 
 class TestDiscoveredTeam:
@@ -114,11 +115,14 @@ class TestDivisionDiscoverer:
         discoverer = DivisionDiscoverer(division="Florida", age_groups=["U14", "U15"])
         assert discoverer.age_groups == ["U14", "U15"]
 
-    def test_season_constants(self):
-        assert SEASON_START.year == 2025
-        assert SEASON_START.month == 9
-        assert SEASON_END.year == 2026
-        assert SEASON_END.month == 6
+    def test_season_constants_track_the_current_season(self):
+        """
+        Pinning these to a literal year is what silently broke discovery when
+        2025-2026 rolled over, so assert the shape instead of the value.
+        """
+        assert SEASON_START == date(current_season_year(), 8, 1)
+        assert SEASON_END == date(current_season_year() + 1, 7, 15)
+        assert SEASON_START < SEASON_END
 
     def test_build_clubs_empty(self):
         discoverer = DivisionDiscoverer(division="Florida")

--- a/tests/unit/test_poll_release_command.py
+++ b/tests/unit/test_poll_release_command.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for the `poll-release` CLI command and the async probe path.
+
+The exit codes are a contract with an unattended CronJob wrapper, so they are
+tested as behaviour rather than as an implementation detail: 10 means "wake
+someone", 20 means "the site may be down", 0 means "go back to sleep".
+"""
+
+import json
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from src.cli.main import app
+from src.models.schedule_release import DivisionRelease, ReleaseProbe, ReleaseState
+from src.scraper.release_detector import ReleaseDetectorError, ScheduleReleaseDetector
+
+runner = CliRunner()
+
+EMPTY_BODY = '<div class="text-center"><p>No data available.</p></div>'
+MATCH_BODY = (
+    '<div class="row table-content-row" js-match-game="1">A vs B</div>'
+    '<div class="row table-content-row" js-match-game="1">C vs D</div>'
+)
+
+
+def _probe(results, season="2026-2027"):
+    return ReleaseProbe(
+        season=season,
+        window_start=date(2026, 8, 1),
+        window_end=date(2026, 12, 31),
+        checked_at=datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc),
+        results=results,
+    )
+
+
+def _result(
+    age="U15", division="Northeast", state=ReleaseState.EMPTY, count=0, error=None
+):
+    return DivisionRelease(
+        age_group=age,
+        division=division,
+        state=state,
+        match_count=count,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async probe path, with the network mocked at the transport layer
+# ---------------------------------------------------------------------------
+
+
+# Captured before any patching: `release_detector` does `import httpx`, so
+# patching `release_detector.httpx.AsyncClient` rebinds the attribute on the
+# shared httpx module. Without this the factory below would call itself.
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _mock_transport(handler):
+    """Patch the detector's client so its requests are served by ``handler``."""
+
+    def factory(**kwargs):
+        return _REAL_ASYNC_CLIENT(transport=httpx.MockTransport(handler), **kwargs)
+
+    return patch("src.scraper.release_detector.httpx.AsyncClient", factory)
+
+
+def _serving(body, status=200):
+    """Patch the detector's client to answer every request identically."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, text=body)
+
+    return _mock_transport(handler)
+
+
+class TestProbeAgainstMockedEndpoint:
+    @pytest.mark.asyncio
+    async def test_empty_response_yields_empty_state(self):
+        detector = ScheduleReleaseDetector(age_groups=["U15"], divisions=["Northeast"])
+
+        with _serving(EMPTY_BODY):
+            probe = await detector.probe()
+
+        assert not probe.is_released
+        assert probe.results[0].state is ReleaseState.EMPTY
+        assert probe.results[0].match_count == 0
+
+    @pytest.mark.asyncio
+    async def test_fixture_rows_yield_live_state(self):
+        detector = ScheduleReleaseDetector(age_groups=["U15"], divisions=["Northeast"])
+
+        with _serving(MATCH_BODY):
+            probe = await detector.probe()
+
+        assert probe.is_released
+        assert probe.results[0].match_count == 2
+        assert probe.total_matches == 2
+
+    @pytest.mark.asyncio
+    async def test_http_error_becomes_an_error_result_not_an_exception(self):
+        """One dead target must not sink the whole probe."""
+        detector = ScheduleReleaseDetector(age_groups=["U15"], divisions=["Northeast"])
+        detector.RETRY_DELAY_BASE = 0  # no need to actually back off in a test
+
+        with _serving("boom", status=503):
+            probe = await detector.probe()
+
+        assert probe.all_failed
+        assert probe.results[0].state is ReleaseState.ERROR
+        assert probe.results[0].error
+
+    @pytest.mark.asyncio
+    async def test_probes_every_age_group_division_pair(self):
+        detector = ScheduleReleaseDetector(
+            age_groups=["U15", "U14"], divisions=["Northeast", "Florida"]
+        )
+
+        with _serving(EMPTY_BODY):
+            probe = await detector.probe()
+
+        assert len(probe.results) == 4
+        assert {r.label for r in probe.results} == {
+            "U15 Northeast",
+            "U14 Northeast",
+            "U15 Florida",
+            "U14 Florida",
+        }
+
+    @pytest.mark.asyncio
+    async def test_request_carries_the_configured_window_and_ids(self):
+        """The season window and IDs must reach the wire, not just the object."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, text=EMPTY_BODY)
+
+        detector = ScheduleReleaseDetector(
+            age_groups=["U15"], divisions=["Mid-Atlantic"], season_year=2026
+        )
+
+        with _mock_transport(handler):
+            await detector.probe()
+
+        url = str(captured[0].url)
+        assert "age%5B%5D=33" in url  # U15
+        assert "groups%5B%5D=68" in url  # Mid-Atlantic
+        assert "2026-08-01" in url
+        assert "2026-12-31" in url
+        assert "status=all" in url
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def _patch_probe(probe):
+    return patch(
+        "src.scraper.release_detector.ScheduleReleaseDetector.probe",
+        new=AsyncMock(return_value=probe),
+    )
+
+
+class TestPollReleaseExitCodes:
+    def test_no_fixtures_exits_zero(self):
+        with _patch_probe(_probe([_result()])):
+            result = runner.invoke(
+                app, ["poll-release", "-a", "U15", "-d", "Northeast"]
+            )
+
+        assert result.exit_code == 0
+        assert "No fixtures published yet" in result.stdout
+
+    def test_newly_live_exits_ten(self):
+        with _patch_probe(_probe([_result(state=ReleaseState.LIVE, count=25)])):
+            result = runner.invoke(
+                app, ["poll-release", "-a", "U15", "-d", "Northeast"]
+            )
+
+        assert result.exit_code == 10
+        assert "Schedule published" in result.stdout
+
+    def test_all_targets_failing_exits_twenty(self):
+        with _patch_probe(_probe([_result(state=ReleaseState.ERROR, error="boom")])):
+            result = runner.invoke(
+                app, ["poll-release", "-a", "U15", "-d", "Northeast"]
+            )
+
+        assert result.exit_code == 20
+        assert "All targets failed" in result.stdout
+
+    def test_error_outranks_new_release_when_everything_failed(self):
+        """A total outage must not be reported as a release."""
+        with _patch_probe(
+            _probe(
+                [
+                    _result(state=ReleaseState.ERROR, error="boom"),
+                    _result(age="U14", state=ReleaseState.ERROR, error="boom"),
+                ]
+            )
+        ):
+            result = runner.invoke(app, ["poll-release"])
+
+        assert result.exit_code == 20
+
+    def test_unknown_division_exits_one(self):
+        result = runner.invoke(app, ["poll-release", "-d", "Atlantis"])
+
+        assert result.exit_code == 1
+        assert "Unknown divisions" in result.stdout
+
+    def test_unknown_age_group_exits_one(self):
+        result = runner.invoke(app, ["poll-release", "-a", "U12"])
+
+        assert result.exit_code == 1
+        assert "Unknown age groups" in result.stdout
+
+
+class TestPollReleaseStateFileIntegration:
+    def test_second_run_does_not_re_alert(self, tmp_path):
+        """The whole point of --state-file: alert once, not every run."""
+        state = tmp_path / "probe.ndjson"
+        probe = _probe([_result(state=ReleaseState.LIVE, count=25)])
+
+        with _patch_probe(probe):
+            first = runner.invoke(
+                app,
+                [
+                    "poll-release",
+                    "-a",
+                    "U15",
+                    "-d",
+                    "Northeast",
+                    "--state-file",
+                    str(state),
+                ],
+            )
+        with _patch_probe(probe):
+            second = runner.invoke(
+                app,
+                [
+                    "poll-release",
+                    "-a",
+                    "U15",
+                    "-d",
+                    "Northeast",
+                    "--state-file",
+                    str(state),
+                ],
+            )
+
+        assert first.exit_code == 10
+        assert second.exit_code == 0
+        assert "already known" in second.stdout
+
+    def test_new_division_after_a_known_one_re_alerts(self, tmp_path):
+        state = tmp_path / "probe.ndjson"
+
+        with _patch_probe(_probe([_result(state=ReleaseState.LIVE, count=25)])):
+            runner.invoke(app, ["poll-release", "--state-file", str(state)])
+
+        with _patch_probe(
+            _probe(
+                [
+                    _result(state=ReleaseState.LIVE, count=25),
+                    _result(division="Florida", state=ReleaseState.LIVE, count=12),
+                ]
+            )
+        ):
+            second = runner.invoke(app, ["poll-release", "--state-file", str(state)])
+
+        assert second.exit_code == 10
+        assert "U15 Florida" in second.stdout
+
+    def test_state_file_records_every_run(self, tmp_path):
+        state = tmp_path / "nested" / "probe.ndjson"
+
+        for _ in range(2):
+            with _patch_probe(_probe([_result()])):
+                runner.invoke(app, ["poll-release", "--state-file", str(state)])
+
+        assert len(state.read_text().strip().splitlines()) == 2
+
+
+class TestPollReleaseJsonOutput:
+    def test_json_output_is_parseable(self):
+        with _patch_probe(_probe([_result(state=ReleaseState.LIVE, count=25)])):
+            result = runner.invoke(
+                app, ["poll-release", "-a", "U15", "-d", "Northeast", "--json"]
+            )
+
+        payload = json.loads(result.stdout)
+        assert payload["season"] == "2026-2027"
+        assert payload["newly_live"] == ["U15 Northeast"]
+        assert payload["results"][0]["state"] == "live"
+
+    def test_json_output_marks_nothing_new_when_empty(self):
+        with _patch_probe(_probe([_result()])):
+            result = runner.invoke(app, ["poll-release", "--json"])
+
+        payload = json.loads(result.stdout)
+        assert payload["newly_live"] == []
+
+
+class TestPollReleaseDisplay:
+    def test_error_rows_are_surfaced_with_detail(self):
+        with _patch_probe(
+            _probe(
+                [
+                    _result(),
+                    _result(
+                        age="U14", state=ReleaseState.ERROR, error="TimeoutError: x"
+                    ),
+                ]
+            )
+        ):
+            result = runner.invoke(app, ["poll-release"])
+
+        assert "TimeoutError" in result.stdout
+        assert result.exit_code == 0, "a partial failure is not an outage"
+
+    def test_full_season_flag_widens_the_window(self):
+        captured = {}
+
+        original_init = ScheduleReleaseDetector.__init__
+
+        def spy(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            captured["fall_only"] = self.fall_only
+
+        with (
+            patch.object(ScheduleReleaseDetector, "__init__", spy),
+            _patch_probe(_probe([_result()])),
+        ):
+            runner.invoke(app, ["poll-release", "--full-season"])
+
+        assert captured["fall_only"] is False
+
+    def test_detector_error_is_reported_cleanly(self):
+        with patch(
+            "src.scraper.release_detector.ScheduleReleaseDetector.probe",
+            new=AsyncMock(side_effect=ReleaseDetectorError("endpoint gone")),
+        ):
+            result = runner.invoke(app, ["poll-release"])
+
+        assert result.exit_code == 1
+        assert "endpoint gone" in result.stdout

--- a/tests/unit/test_poll_release_state.py
+++ b/tests/unit/test_poll_release_state.py
@@ -1,0 +1,106 @@
+"""
+Tests for the poll-release state file (SB-499).
+
+The state file is what makes an unattended poller alert *once* on release
+rather than every run, so its failure modes matter more than its happy path: a
+poller that double-alerts is annoying, one that crashes on a bad line stops
+alerting entirely.
+"""
+
+import json
+from datetime import date, datetime, timezone
+
+from src.cli.main import _append_probe_state, _load_live_targets
+from src.models.schedule_release import DivisionRelease, ReleaseProbe, ReleaseState
+
+
+def _probe(results):
+    return ReleaseProbe(
+        season="2026-2027",
+        window_start=date(2026, 8, 1),
+        window_end=date(2026, 12, 31),
+        checked_at=datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc),
+        results=results,
+    )
+
+
+def _live(age="U15", division="Northeast", count=25):
+    return DivisionRelease(
+        age_group=age, division=division, state=ReleaseState.LIVE, match_count=count
+    )
+
+
+def _empty(age="U15", division="Northeast"):
+    return DivisionRelease(age_group=age, division=division, state=ReleaseState.EMPTY)
+
+
+class TestLoadLiveTargets:
+    def test_missing_file_yields_nothing(self, tmp_path):
+        assert _load_live_targets(tmp_path / "absent.ndjson") == set()
+
+    def test_none_path_yields_nothing(self):
+        assert _load_live_targets(None) == set()
+
+    def test_reads_live_targets_only(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        _append_probe_state(
+            path, _probe([_live(), _empty(age="U14")]), newly_live=[_live()]
+        )
+
+        assert _load_live_targets(path) == {"U15 Northeast"}
+
+    def test_accumulates_across_runs(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        _append_probe_state(path, _probe([_live()]), newly_live=[_live()])
+        _append_probe_state(
+            path,
+            _probe([_live(), _live(division="Florida")]),
+            newly_live=[_live(division="Florida")],
+        )
+
+        assert _load_live_targets(path) == {"U15 Northeast", "U15 Florida"}
+
+    def test_malformed_lines_are_skipped_not_fatal(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        _append_probe_state(path, _probe([_live()]), newly_live=[_live()])
+        with path.open("a") as f:
+            f.write("this is not json\n")
+            f.write("\n")
+
+        assert _load_live_targets(path) == {"U15 Northeast"}
+
+    def test_empty_file_yields_nothing(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        path.write_text("")
+        assert _load_live_targets(path) == set()
+
+
+class TestAppendProbeState:
+    def test_creates_parent_directories(self, tmp_path):
+        path = tmp_path / "nested" / "deeper" / "probe.ndjson"
+        _append_probe_state(path, _probe([_empty()]), newly_live=[])
+
+        assert path.exists()
+
+    def test_records_newly_live_labels(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        _append_probe_state(path, _probe([_live()]), newly_live=[_live()])
+
+        record = json.loads(path.read_text().strip())
+        assert record["newly_live"] == ["U15 Northeast"]
+        assert record["season"] == "2026-2027"
+
+    def test_one_line_per_probe(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        for _ in range(3):
+            _append_probe_state(path, _probe([_empty()]), newly_live=[])
+
+        assert len(path.read_text().strip().splitlines()) == 3
+
+    def test_empty_probe_records_no_new_targets(self, tmp_path):
+        path = tmp_path / "probe.ndjson"
+        _append_probe_state(path, _probe([_empty()]), newly_live=[])
+
+        record = json.loads(path.read_text().strip())
+        assert record["newly_live"] == []
+        assert _load_live_targets(path) == set()

--- a/tests/unit/test_release_detector.py
+++ b/tests/unit/test_release_detector.py
@@ -1,0 +1,213 @@
+"""Unit tests for schedule release detection (SB-499)."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src.models.schedule_release import DivisionRelease, ReleaseProbe, ReleaseState
+from src.scraper.modular11 import (
+    AGE_GROUP_IDS,
+    DIVISION_GROUP_IDS,
+    PRIORITY_DIVISIONS,
+    current_season_year,
+    fall_segment_window,
+    season_label,
+    season_window,
+)
+from src.scraper.release_detector import (
+    ReleaseDetectorError,
+    ScheduleReleaseDetector,
+    count_matches,
+)
+
+# The pre-release response, verbatim from the live endpoint on 2026-08-02.
+EMPTY_RESPONSE = '<div class="text-center"><p>No data available.</p></div>'
+
+MATCH_ROW = (
+    '<div class="row table-content-row" js-match-game="1" '
+    'js-match-group="Northeast">Downtown United vs Long Island</div>'
+)
+
+
+class TestSeasonHelpers:
+    """Season boundaries must be derived, not pinned — that is what went stale."""
+
+    @pytest.mark.parametrize(
+        ("today", "expected"),
+        [
+            (date(2026, 8, 1), 2026),  # first day of the season
+            (date(2026, 8, 2), 2026),
+            (date(2026, 12, 31), 2026),
+            (date(2027, 1, 1), 2026),  # still the 2026-2027 season
+            (date(2027, 7, 31), 2026),
+            (date(2027, 8, 1), 2027),  # rolls over
+        ],
+    )
+    def test_current_season_year(self, today, expected):
+        assert current_season_year(today) == expected
+
+    def test_season_label_format_matches_agent(self):
+        """The agent posts '2026-2027'; this repo must not diverge to '26-27'."""
+        assert season_label(2026) == "2026-2027"
+
+    def test_season_window_spans_august_to_july(self):
+        start, end = season_window(2026)
+        assert start == date(2026, 8, 1)
+        assert end == date(2027, 7, 15)
+
+    def test_fall_segment_stops_at_year_end(self):
+        start, end = fall_segment_window(2026)
+        assert start == date(2026, 8, 1)
+        assert end == date(2026, 12, 31)
+
+    def test_fall_window_is_inside_season_window(self):
+        s_start, s_end = season_window(2026)
+        f_start, f_end = fall_segment_window(2026)
+        assert s_start <= f_start
+        assert f_end <= s_end
+
+
+class TestModular11Constants:
+    def test_priority_divisions_are_known(self):
+        for division in PRIORITY_DIVISIONS:
+            assert division in DIVISION_GROUP_IDS
+
+    def test_priority_division_ids_match_live_site(self):
+        """Verified against select[js-groups] on 2026-08-02."""
+        assert DIVISION_GROUP_IDS["Northeast"] == "41"
+        assert DIVISION_GROUP_IDS["Florida"] == "46"
+        assert DIVISION_GROUP_IDS["Mid-Atlantic"] == "68"
+
+    def test_age_group_ids_match_live_site(self):
+        assert AGE_GROUP_IDS == {
+            "U13": "21",
+            "U14": "22",
+            "U15": "33",
+            "U16": "14",
+            "U17": "15",
+            "U19": "26",
+        }
+
+
+class TestCountMatches:
+    def test_empty_marker_counts_as_zero(self):
+        assert count_matches(EMPTY_RESPONSE) == 0
+
+    def test_empty_marker_is_case_insensitive(self):
+        assert count_matches("<p>NO DATA AVAILABLE.</p>") == 0
+
+    def test_blank_response_counts_as_zero(self):
+        assert count_matches("") == 0
+        assert count_matches("   \n  ") == 0
+
+    def test_counts_match_rows(self):
+        assert count_matches(MATCH_ROW * 3) == 3
+
+    def test_html_without_rows_counts_as_zero(self):
+        assert count_matches("<div class='wrapper'><p>Something else</p></div>") == 0
+
+
+class TestDetectorValidation:
+    def test_rejects_unknown_age_group(self):
+        with pytest.raises(ReleaseDetectorError, match="Unknown age groups"):
+            ScheduleReleaseDetector(age_groups=["U12"])
+
+    def test_rejects_unknown_division(self):
+        with pytest.raises(ReleaseDetectorError, match="Unknown divisions"):
+            ScheduleReleaseDetector(divisions=["Atlantis"])
+
+    def test_defaults_to_priority_targets(self):
+        detector = ScheduleReleaseDetector()
+        assert detector.divisions == list(PRIORITY_DIVISIONS)
+        assert detector.age_groups[0] == "U15", "U15 is the top priority for SB-499"
+
+    def test_fall_only_narrows_the_window(self):
+        full = ScheduleReleaseDetector(season_year=2026, fall_only=False).window
+        fall = ScheduleReleaseDetector(season_year=2026, fall_only=True).window
+        assert fall[1] < full[1]
+
+
+def _result(age="U15", division="Northeast", state=ReleaseState.EMPTY, count=0):
+    return DivisionRelease(
+        age_group=age, division=division, state=state, match_count=count
+    )
+
+
+def _probe(results):
+    return ReleaseProbe(
+        season="2026-2027",
+        window_start=date(2026, 8, 1),
+        window_end=date(2026, 12, 31),
+        checked_at=datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc),
+        results=results,
+    )
+
+
+class TestReleaseProbe:
+    def test_all_empty_is_not_released(self):
+        probe = _probe([_result(), _result(age="U14")])
+        assert not probe.is_released
+        assert not probe.all_failed
+        assert probe.total_matches == 0
+
+    def test_one_live_target_means_released(self):
+        probe = _probe(
+            [_result(), _result(age="U14", state=ReleaseState.LIVE, count=25)]
+        )
+        assert probe.is_released
+        assert len(probe.live) == 1
+        assert probe.total_matches == 25
+
+    def test_all_errors_flagged_separately_from_empty(self):
+        """'MLS Next is down' must not read the same as 'schedule not out yet'."""
+        probe = _probe(
+            [
+                _result(state=ReleaseState.ERROR),
+                _result(age="U14", state=ReleaseState.ERROR),
+            ]
+        )
+        assert probe.all_failed
+        assert not probe.is_released
+
+    def test_partial_errors_are_not_all_failed(self):
+        probe = _probe([_result(), _result(age="U14", state=ReleaseState.ERROR)])
+        assert not probe.all_failed
+        assert len(probe.errors) == 1
+
+    def test_empty_result_set_is_not_all_failed(self):
+        assert not _probe([]).all_failed
+
+    def test_summary_mentions_live_targets(self):
+        probe = _probe([_result(state=ReleaseState.LIVE, count=25)])
+        summary = probe.summary()
+        assert "U15 Northeast" in summary
+        assert "2026-2027" in summary
+
+    def test_summary_when_nothing_published(self):
+        assert "no fixtures yet" in _probe([_result()]).summary()
+
+    def test_summary_when_everything_failed(self):
+        probe = _probe([_result(state=ReleaseState.ERROR)])
+        assert "failed to probe" in probe.summary()
+
+
+class TestDivisionRelease:
+    def test_label_is_age_then_division(self):
+        assert _result().label == "U15 Northeast"
+
+    def test_age_group_is_upper_cased(self):
+        assert (
+            DivisionRelease(
+                age_group=" u15 ", division="Northeast", state=ReleaseState.EMPTY
+            ).age_group
+            == "U15"
+        )
+
+    def test_blank_division_rejected(self):
+        with pytest.raises(ValueError):
+            DivisionRelease(age_group="U15", division="  ", state=ReleaseState.EMPTY)
+
+    def test_is_live_tracks_state(self):
+        assert _result(state=ReleaseState.LIVE).is_live
+        assert not _result(state=ReleaseState.EMPTY).is_live
+        assert not _result(state=ReleaseState.ERROR).is_live

--- a/tests/unit/test_scrape_agent.py
+++ b/tests/unit/test_scrape_agent.py
@@ -322,9 +322,19 @@ class TestBuildMatchDict:
 
         assert result["match_date"] == "2025-10-18"
 
-    def test_season_hardcoded(self):
-        result = build_match_dict(_make_match(), _make_config())
-        assert result["season"] == "2024-25"
+    def test_season_derived_from_match_date(self):
+        """A fall match belongs to the season starting that August."""
+        match = _make_match(match_datetime=datetime(2026, 10, 18, 14, 0))
+        result = build_match_dict(match, _make_config())
+
+        assert result["season"] == "2026-2027"
+
+    def test_season_spring_match_belongs_to_prior_year(self):
+        """A spring match belongs to the season that started the previous August."""
+        match = _make_match(match_datetime=datetime(2027, 3, 14, 14, 0))
+        result = build_match_dict(match, _make_config())
+
+        assert result["season"] == "2026-2027"
 
     def test_age_group_from_config(self):
         config = _make_config(age_group="U16")


### PR DESCRIPTION
## What and why

MLS Next has rolled over to the 2026-2027 season but has **not published any fixtures yet**. This adds an HTTP-only detector so the release can be caught unattended over the weekend, and fixes the season constants that silently went stale in the rollover.

Verified live against the site on 2026-08-02.

## What the rollover actually did

| Observation | Evidence |
|---|---|
| Schedule iframe moved to a new season token | `modular11.com/schedule?year=21` |
| Prior-season dates rejected by the calendar | Scraping 2025-09-05 fails: `Failed to navigate to start date month` after 4 attempts |
| QoP standings wiped | Endpoint returns `There are no teams.` for **all six** age groups — the weekly QoP CronJob is currently producing nothing |
| Fixtures not yet published | `get_matches` returns `No data available.` for every priority target |
| Clubs *are* populated | 260 entries in the club dropdown |

## The detector

The schedule iframe fetches fixtures from a plain GET endpoint, so detection needs no browser — **18 targets in about a second**:

```
GET modular11.com/public_schedule/league/get_matches?tournament=12&age[]=33&groups[]=41&status=all...
```

Before publication it answers `No data available.` in ~70 bytes; afterwards it returns one `[js-match-game]` row per fixture. That difference is the whole signal.

New `poll-release` command, with exit codes as the notification contract for a scheduled caller:

| Code | Meaning |
|------|---------|
| `0`  | Nothing new — no fixtures, or fixtures already known |
| `10` | Newly published fixtures — notify |
| `20` | Every target failed to probe — notify if it persists |

`--state-file` records which targets have been seen live, so a poll alerts **once** on release rather than every run. A missing or corrupt state file degrades to "nothing seen yet" rather than crashing the poller — a double alert is a nuisance, a dead poller is a miss.

Validated end to end against the live site: current season → `empty`/exit 0; 2025-2026 → `live (25)`/exit 10; same again → exit 0.

## Stale constants fixed

- **`build_match_dict` posted a hardcoded `"2024-25"`** — two seasons behind, and in the 4-2 form while match-scraper-agent posts 4-4. Now derived from the *match date* (so a spring match still belongs to the season that started the prior August) in the `2026-2027` form.
- **`division_discovery` pinned `SEASON_START/END`** to 2025-09-01/2026-06-30, so discovery silently found nothing after rollover. Now derived.

All season maths now lives in `src/scraper/modular11.py`.

## Division ID drift — deliberately *not* auto-applied

The site renumbered several divisions:

| Division | 2025-26 | 2026-27 |
|---|---|---|
| Southeast | 37 | **45** |
| Southwest | 36 | **52** |
| Northwest | 38 | **57** |
| Great Lakes / Texas / California | 39/40/42 | *removed* |
| West / Frontier / Mid-America / MLS Academy | — | 33/66/67/225 |

**Northeast (41), Florida (46) and Mid-Atlantic (68) — the divisions we scrape — are unchanged.**

Site-side IDs now live in `modular11.py`. They are deliberately **not** copied into `division_lookup.DIVISION_ID_MAP`: those integers are posted to missing-table as `division_id`, so matching the site would point at divisions missing-table does not have. Reconcile explicitly before scraping Southeast/Southwest/Northwest.

## Bonus finding

`get_matches` **still serves prior-season data** (166KB for U15 Northeast 2025-26, with match IDs and scores) even though the calendar UI refuses those dates. The Playwright block is a UI limitation, not a data one — so a backfill path survives.

## Testing

- 629 unit tests pass (up from 610); ruff clean; pre-commit diff-coverage gate passed
- New: async probe paths via mocked transport, CLI exit-code contract, state-file failure modes, season-boundary maths
- Fixed a real bug found by the tests: `--json` used `console.print_json`, which wraps output in ANSI colour and would have broken `jq` in the CronJob. Now plain stdout, verified piping through `jq`
- Two pre-existing tests updated because they asserted the stale values (`test_season_hardcoded`, `test_season_constants`) — both rewritten to assert the invariant rather than a pinned year

## Not in this PR

Per the agreed split, the CronJob + Telegram wiring lands in **match-scraper-agent** (needs a SHA bump to this commit). Behaviour on detection is **notify-only** — no unattended scrape against an unverified new-season page.

Fixes SB-499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
