### PR TITLE
fix: Restore the agent-state PVC mount to the agent CronJob

### DIFF
--- a/k3s/agent/cronjob.yaml
+++ b/k3s/agent/cronjob.yaml
@@ -25,6 +25,15 @@ spec:
                     name: match-scraper-agent-config
                 - secretRef:
                     name: match-scraper-agent-secret
+              volumeMounts:
+                # The run journal lives here — the previous run's per-target
+                # results, which the modifier rules read to retry a target
+                # that errored. PR #57 removed this mount when the journal
+                # moved to S3; the cluster kept it, and SB-555 made the code
+                # use it again. Without it the agent silently loses its
+                # cross-run memory.
+                - name: agent-state
+                  mountPath: /data/agent-state
               resources:
                 requests:
                   cpu: 200m
@@ -32,3 +41,7 @@ spec:
                 limits:
                   cpu: "1"
                   memory: 2Gi
+          volumes:
+            - name: agent-state
+              persistentVolumeClaim:
+                claimName: agent-state


### PR DESCRIPTION
`kubectl diff` caught this immediately before the agent cutover in SB-570.

The CronJob manifest carried over from the agent repo has no `volumeMounts`, so applying it would have **removed the `agent-state` PVC from the running CronJob**:

```
-            volumeMounts:
-            - mountPath: /data/agent-state
-              name: agent-state
-          volumes:
-          - name: agent-state
-            persistentVolumeClaim:
-              claimName: agent-state
```

PR #57 stripped the mount when it moved the journal to S3. The live cluster kept it anyway, and SB-555 (yesterday) made the code read and write it again. So applying the repo's version would have taken the agent's cross-run memory away on the same day it was restored — and with it `error_retry`, the rule that re-scrapes a target after it fails. Nothing would have failed loudly; the journal would just have stopped existing again.

With this, the diff against the live CronJob is image-only, which is what a cutover should be.

## Verified

Applied, then a full manual run on the consolidated image, 15 minutes:

```
{"run_id": "54671114efbf", "event": "journal.loaded"}
{"summary": "7 targets scraped, 0 skipped — 0 matches found, 0 submitted"}
{"path": "/data/agent-state/journal.json", "event": "journal.written"}
```

Both ends of the journal work on the new image. 0 matches is correct — offseason, no fixtures published.

Refs SB-570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
